### PR TITLE
Remove worker_queues resource requests if deployment uses Kubernetes Executor

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -133,8 +133,13 @@ runs:
 
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
-          
-          # Create new deploymeent preview based on the deployment template file
+
+          # Remove worker_queues resource requests if deployment uses Kubernetes Executor
+          if [[ $(yq -r .deployment.configuration.executor deployment-preview-template.yaml) == "KubernetesExecutor" ]] then
+            cat deployment-preview-template.yaml |  yq -y 'del(.deployment.worker_queues[] | .pod_cpu, .pod_ram)' | tee deployment-preview-template.yaml
+          fi
+
+          # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml
 
           # Get final deployment ID

--- a/action.yaml
+++ b/action.yaml
@@ -76,6 +76,7 @@ runs:
     - name: Install Astro
       run: |
         curl -sSL https://install.astronomer.io | sudo bash -s
+        pip3 install yq
       shell: bash
     - name: Deployment Preview action
       run: |


### PR DESCRIPTION
If the deployment uses the Kubernetes Executor, the worker_queues will contain the `pod_cpu` & `pod_ram` specs, and then when `astro deployment create` is applied, it will complain that:

```
Error: KubernetesExecutor does not support pod cpu in the request. It will be calculated based on the requested worker type
```