### PR TITLE
make checkout step optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `image-name` | | Specifies a custom, locally built image to deploy |
 | `workspace` | `false` | If you are using an organization token you will need to provide a workspace-name or id |
 | `preview-name` | `false` | Specifies custom preview name. By default this is branch name “_” deployment name |
+| `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action |
 
 
 ## Workflow file examples

--- a/action.yaml
+++ b/action.yaml
@@ -60,6 +60,10 @@ inputs:
     required: false
     default: true
     description: "Copy pools from the original Deployment to the new deployment preview."
+  checkout:
+    required: false
+    default: true
+    description: "Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action"
 outputs:
   preview-id:
     description: "The ID of the created deployment preview. Only works when action=create-deployment-preview"
@@ -70,6 +74,7 @@ runs:
   steps:
     - name: checkout repo
       uses: actions/checkout@v3
+      if: inputs.checkout == true
       with:
         fetch-depth: 2
         clean: false


### PR DESCRIPTION
add `checkout` parameter to make the checkout step optional. this is useful if you need to modify some checked out files before invoking the action