### PR TITLE
Fix custom root-folder example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ steps:
   uses: astronomer/deploy-action@v0.2
   with:
     deployment-id: <deployment id>
-    root-folder: /example-dags/dags/
+    root-folder: /example-dags
 ```
 
 ### Run Pytests


### PR DESCRIPTION
This example was using the `root-folder` option incorrectly, passing the value that includes `dags` folder.