### PR TITLE
Run yamllint on PR

### DIFF
--- a/.github/workflows/lint_yaml.yaml
+++ b/.github/workflows/lint_yaml.yaml
@@ -1,5 +1,7 @@
 name: Lint YAML
-on: push
+on:
+  pull_request:
+    branches: ['main']
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_yaml.yaml
+++ b/.github/workflows/lint_yaml.yaml
@@ -1,0 +1,11 @@
+name: Lint YAML
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: action.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,11 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  document-start:
+    present: false
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false  # disabled because Bash scripts contain indented code

--- a/action.yaml
+++ b/action.yaml
@@ -1,8 +1,8 @@
 name: "Deploy Apache Airflow DAGs to Astro"
 description: "Test your DAGs and deploy your Astro project to a Deployment on Astro, Astronomer's managed Airflow service."
 branding:
-    icon: 'upload-cloud'
-    color: 'purple'
+  icon: 'upload-cloud'
+  color: 'purple'
 inputs:
   root-folder:
     required: false
@@ -110,8 +110,6 @@ runs:
         # create deployment preview if action is create-deployment-preview
         if [[ ${{ inputs.action }} == create-deployment-preview ]]; then
 
-
-
           if [[ "${{ inputs.deployment-name }}" == false && ${{ inputs.deployment-id }} == false ]]; then
             echo ERROR: cannot create a deployment preview without specifying a deployment name or id
             exit 1 # terminate and indicate error
@@ -120,7 +118,7 @@ runs:
           if [[ ${{ inputs.preview-name }} != false ]]; then
             BRANCH_DEPLOYMENT_NAME=${{ inputs.preview-name }}
 
-          else 
+          else
             # get branch name
             DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
             if [[ ${GITHUB_HEAD_REF##*/} != "" ]]; then
@@ -139,7 +137,7 @@ runs:
 
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
-          
+
           # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml
 
@@ -170,7 +168,7 @@ runs:
           if [[ ${{ inputs.preview-name }} != false ]]; then
             BRANCH_DEPLOYMENT_NAME=${{ inputs.preview-name }}
 
-          else 
+          else
             DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
             BRANCH_DEPLOYMENT_NAME=${{ github.event.ref }}_$DEPLOYMENT_NAME
             BRANCH_DEPLOYMENT_NAME="${BRANCH_DEPLOYMENT_NAME// /_}"
@@ -187,7 +185,7 @@ runs:
           # set action
           ACTION=delete
         fi
-        
+
         # # deploy to deployment preview if action is deploy-deployment-preview
         if [[ ${{ inputs.action }} == deploy-deployment-preview ]]; then
 
@@ -198,7 +196,7 @@ runs:
 
           if [[ ${{ inputs.preview-name }} != false ]]; then
             BRANCH_DEPLOYMENT_NAME=${{ inputs.preview-name }}
-          else 
+          else
             DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
             if [[ ${GITHUB_HEAD_REF##*/} != "" ]]; then
               BRANCH_DEPLOYMENT_NAME=${GITHUB_HEAD_REF##*/}_$DEPLOYMENT_NAME
@@ -216,7 +214,7 @@ runs:
 
           # don't skip deploy
           echo "SKIP_DEPLOY=false" >> $GITHUB_OUTPUT
-          
+
           # not image deploy only
           echo "IMAGE_DEPLOY_ONLY=false" >> $GITHUB_OUTPUT
 
@@ -272,7 +270,7 @@ runs:
         fi
 
         if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == true ]]; then
-          # skip all deploy steps 
+          # skip all deploy steps
           dags_only=2
         fi
 
@@ -298,7 +296,7 @@ runs:
         if [[ ${{ inputs.image-name }} != no-custom-image ]]; then
           options="$options --image-name ${{ inputs.image-name }}"
         fi
-        
+
         # add force option
         if [[ ${{ inputs.force }} == true ]]; then
           options="$options --force"
@@ -334,4 +332,3 @@ runs:
           fi
         fi
       shell: bash
-  


### PR DESCRIPTION
I suggest running [yamllint](https://www.yamllint.com/) on PRs to main to improve consistency in the `action.yaml` file. I checked a few yamllint GitHub actions in the marketplace and found ibiqlik/action-yamllint to be popular, so went with that.

yamllint can also be run manually on the command line with `yamllint -c .yamllint action.yaml`.