### PR TITLE
chore: update actions/checkout to v4

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ runs:
   using: "composite"
   steps:
     - name: checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ inputs.checkout }} == true
       with:
         fetch-depth: 2


### PR DESCRIPTION
This updates `actions/checkout` to v4 to resolve https://github.com/astronomer/deploy-action/issues/50.