### PR TITLE
main - Skip tasks that shouldn't run on skip_deploy

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -266,6 +266,7 @@ runs:
       shell: bash
       id: dag-deploy-enabled
     - name: Get Deployment Type
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == false
       run: |
         cd ${{ inputs.root-folder }}
         branch=$(echo "${GITHUB_REF#refs/heads/}")
@@ -287,11 +288,6 @@ runs:
           dags_only=0
         fi
 
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == true ]]; then
-          # skip all deploy steps
-          dags_only=2
-        fi
-
         if [[ ${{ inputs.deploy-image }} == true ]]; then
           # make sure image and DAGs deploys because deploy-image is true
           dags_only=0
@@ -302,6 +298,7 @@ runs:
       id: deployment-type
     # If only DAGs changed and dag deploys is enabled, do a DAG-only deploy
     - name: setup deploy options
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == false
       run: |
         options=""
 
@@ -347,6 +344,7 @@ runs:
         astro deploy ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} ${{steps.deploy-options.outputs.OPTIONS}}
       shell: bash
     - name: Copy Airflow Connections, Variables, and Pools
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == false
       run: |
         if [[ ${{ inputs.action }} == create-deployment-preview ]]; then
           if [[ ${{ inputs.copy-connections }} == true ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -272,7 +272,7 @@ runs:
         branch=$(echo "${GITHUB_REF#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
-        files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+        files=$(git diff --name-only $(git rev-parse HEAD^) ${{ github.event.after }})
         echo "files changed: $files"
         dags_only=1
 


### PR DESCRIPTION
I have some issues on delete-deployment-preview on closing PR
Those steps that shouldn't need to run at all when deleting deployments, so I set the condition to skip those steps when SKIP_DEPLOY is true