### PR TITLE
Skip tasks that shouldn't run on skip_deploy

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -339,15 +339,15 @@ runs:
       shell: bash
       id: deploy-options
     - name: Determine if Development Mode is enabled
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false ]]; then
-          echo "DEVELOPMENT_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)" >> $GITHUB_OUTPUT
-        fi
+        echo "DEVELOPMENT_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)" >> $GITHUB_OUTPUT
       shell: bash
       id: development-mode
     - name: Override to wake up the Deployment
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false && ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
+        if [[ ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
           astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
           # Give it some time to wake up
           sleep 60
@@ -382,8 +382,9 @@ runs:
         fi
       shell: bash
     - name: Remove override on Deployment to resume schedule
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false && ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
+        if [[ ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
           astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --remove-override --force
         fi
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -269,12 +269,13 @@ runs:
       shell: bash
       id: dag-deploy-enabled
     - name: Get Deployment Type
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         cd ${{ inputs.root-folder }}
         branch=$(echo "${GITHUB_REF#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
-        files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+        files=$(git diff --name-only $(git rev-parse HEAD^) ${{ github.event.after }})
         echo "files changed: $files"
         dags_only=1
 
@@ -290,11 +291,6 @@ runs:
           dags_only=0
         fi
 
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == true ]]; then
-          # skip all deploy steps
-          dags_only=2
-        fi
-
         if [[ ${{ inputs.deploy-image }} == true ]]; then
           # make sure image and DAGs deploys because deploy-image is true
           dags_only=0
@@ -305,6 +301,7 @@ runs:
       id: deployment-type
     # If only DAGs changed and dag deploys is enabled, do a DAG-only deploy
     - name: setup deploy options
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         options=""
 
@@ -357,19 +354,20 @@ runs:
         fi
       shell: bash
     - name: DAG Deploy to Astro
-      if: steps.deployment-type.outputs.DAGS_ONLY == 1
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false' && steps.deployment-type.outputs.DAGS_ONLY == 1
       run: |
         cd ${{ inputs.root-folder }}
         astro deploy ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --dags ${{steps.deploy-options.outputs.OPTIONS}}
       shell: bash
     # If any other files changed or dag deploys is disabled, deploy the entire Astro project
     - name: Image and DAG Deploy to Astro
-      if: steps.deployment-type.outputs.DAGS_ONLY == 0
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false' && steps.deployment-type.outputs.DAGS_ONLY == 0
       run: |
         cd ${{ inputs.root-folder }}
         astro deploy ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} ${{steps.deploy-options.outputs.OPTIONS}}
       shell: bash
     - name: Copy Airflow Connections, Variables, and Pools
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         if [[ ${{ inputs.action }} == create-deployment-preview ]]; then
           if [[ ${{ inputs.copy-connections }} == true ]]; then


### PR DESCRIPTION
- Skip tasks that shouldn't run on skip_deploy
- use $(git rev-parse HEAD^) instead of github.event.before, so squashed commits that are forced-pushed work

I had opened a PR earlier that was not properly tested, but this one should be better and tested, it fixes two issues we were facing with our deployments