### PR TITLE
add dag-only-deploy parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `preview-name` | `false` | Specifies custom preview name. By default this is branch name “_” deployment name. |
 | `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action. Your custom checkout step needs to have `fetch-depth` of `0` and `ref` equal to `${{ github.event.after }}` so all the commits in the PR are checked out. Look at the checkout step that runs within this action for reference. |
 | `deploy-image` | `false` | If true image and DAGs will deploy for any action that deploys code. |
+| `dag-only-deploy` | `false` | If true only DAGs will deploy. |
 | `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
 
 

--- a/action.yaml
+++ b/action.yaml
@@ -79,6 +79,10 @@ inputs:
     required: false
     default: false
     description: "If true image and DAGs will deploy"
+  dag-only-deploy:
+    required: false
+    default: false
+    description: "If true only DAGs will deploy"
   build-secrets:
     required: false
     description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
@@ -298,6 +302,11 @@ runs:
         if [[ ${{ inputs.deploy-image }} == true ]]; then
           # make sure image and DAGs deploys because deploy-image is true
           dags_only=0
+        fi
+
+        if [[ ${{ inputs.dag-only-deploy }} == true ]]; then
+          # make sure only DAGs deploys because dag-only-deploy is true
+          dags_only=1
         fi
 
         echo "DAGS_ONLY=$dags_only" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR adds a `dag-only-deploy` parameter for the use cases to force DAG only deploys.
Solves the issue: https://github.com/astronomer/deploy-action/issues/64