### PR TITLE
Add support for submodule cloning during checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action. Your custom checkout step needs to have `fetch-depth` of `0` and `ref` equal to `${{ github.event.after }}` so all the commits in the PR are checked out. Look at the checkout step that runs within this action for reference. |
 | `deploy-image` | `false` | If true image and DAGs will deploy for any action that deploys code. |
 | `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
-| `submodule` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. |
+| `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action. Your custom checkout step needs to have `fetch-depth` of `0` and `ref` equal to `${{ github.event.after }}` so all the commits in the PR are checked out. Look at the checkout step that runs within this action for reference. |
 | `deploy-image` | `false` | If true image and DAGs will deploy for any action that deploys code. |
 | `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
+| `submodule` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. |
 
 
 ## Outputs

--- a/action.yaml
+++ b/action.yaml
@@ -82,7 +82,7 @@ inputs:
   build-secrets:
     required: false
     description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
-  submodule:
+  checkout-submodules:
     required: false
     default: false
     description: "Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`."
@@ -101,7 +101,7 @@ runs:
         fetch-depth: 0 # Fetch all history
         ref: ${{ github.event.after }}
         clean: false
-        submodules: ${{ inputs.submodule }}
+        submodules: ${{ inputs.checkout-submodules }}
     - name: Install Astro CLI
       run: |
         curl -sSL https://install.astronomer.io | sudo bash -s ${{ inputs.cli-version }}

--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: "Deploy Apache Airflow DAGs to Astro"
 description: "Test your DAGs and deploy your Astro project to a Deployment on Astro, Astronomer's managed Airflow service."
 author: "Astronomer"
 branding:
-  icon: 'upload-cloud'
-  color: 'purple'
+  icon: "upload-cloud"
+  color: "purple"
 inputs:
   root-folder:
     required: false
@@ -82,6 +82,10 @@ inputs:
   build-secrets:
     required: false
     description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
+  submodule:
+    required: false
+    default: false
+    description: "Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`."
 outputs:
   preview-id:
     description: "The ID of the created deployment preview. Only works when action=create-deployment-preview"
@@ -94,9 +98,10 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout == 'true'
       with:
-        fetch-depth: 0  # Fetch all history
+        fetch-depth: 0 # Fetch all history
         ref: ${{ github.event.after }}
         clean: false
+        submodules: ${{ inputs.submodule }}
     - name: Install Astro CLI
       run: |
         curl -sSL https://install.astronomer.io | sudo bash -s ${{ inputs.cli-version }}


### PR DESCRIPTION
### Changes:

- Add a new input `submodule` to allow cloning the repo including submodules. Possible values are `true`, `false` (default), and `recursive`. Works only when `checkout` is set to true. SSH URLs beginning with `git@github.com:` are converted to HTTPS.

Closes: #76 

### Testing:

- Case with submodule disabled (default case):
<img width="1055" alt="Screenshot 2024-09-04 at 3 43 05 PM" src="https://github.com/user-attachments/assets/6649b8c4-0e9d-4704-92e5-cad1e39cdd71">

- Case with submodule set to true:
<img width="1807" alt="Screenshot 2024-09-04 at 3 43 31 PM" src="https://github.com/user-attachments/assets/6a4edc0c-368f-408b-8b68-08453125cb5a">

- Case with submodule set to recursive:
<img width="1806" alt="Screenshot 2024-09-04 at 3 43 56 PM" src="https://github.com/user-attachments/assets/c2ff397f-f509-4d05-a351-10f9955a301a">

