### PR TITLE
Fix development mode check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: "Deploy Apache Airflow DAGs to Astro"
 description: "Test your DAGs and deploy your Astro project to a Deployment on Astro, Astronomer's managed Airflow service."
 author: "Astronomer"
 branding:
-  icon: 'upload-cloud'
-  color: 'purple'
+  icon: "upload-cloud"
+  color: "purple"
 inputs:
   root-folder:
     required: false
@@ -94,7 +94,7 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout == 'true'
       with:
-        fetch-depth: 0  # Fetch all history
+        fetch-depth: 0 # Fetch all history
         ref: ${{ github.event.after }}
         clean: false
     - name: Install Astro CLI
@@ -344,7 +344,12 @@ runs:
     - name: Determine if Development Mode is enabled
       run: |
         if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false ]]; then
-          echo "DEVELOPMENT_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)" >> $GITHUB_OUTPUT
+          DEV_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)
+          if [[ $DEV_MODE == "" ]]; then
+            echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
+          else
+            echo "DEVELOPMENT_MODE=$DEV_MODE" >> $GITHUB_OUTPUT
+          fi
         fi
       shell: bash
       id: development-mode

--- a/action.yaml
+++ b/action.yaml
@@ -344,11 +344,17 @@ runs:
     - name: Determine if Development Mode is enabled
       run: |
         if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false ]]; then
-          DEV_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)
-          if [[ $DEV_MODE == "" ]]; then
-            echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
+          DEPLOYMENT_TYPE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.deployment_type)
+          # only inspect development mode if deployment is not hybrid
+          if [[ $DEPLOYMENT_TYPE != "HYBRID" ]]; then
+            DEV_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)
+            if [[ $DEV_MODE == "" ]]; then
+              echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
+            else
+              echo "DEVELOPMENT_MODE=$DEV_MODE" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "DEVELOPMENT_MODE=$DEV_MODE" >> $GITHUB_OUTPUT
+            echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
           fi
         fi
       shell: bash


### PR DESCRIPTION
### Changes:

Fixes deployment mode check when deployment is not configured as development deployment

### Testing:

- Tried creating/deploying to a deployment that is not a development deployment
<img width="1088" alt="Screenshot 2024-09-04 at 5 13 09 PM" src="https://github.com/user-attachments/assets/177ef18e-4c62-45da-a512-301baa97105a">

- Case when deployment is of the type HYBRID:
<img width="1016" alt="Screenshot 2024-09-04 at 6 11 57 PM" src="https://github.com/user-attachments/assets/c9ba3627-7b0a-456a-9ac7-b6dd11d19673">

- Tried creating/deploying to a deployment that is a development deployment and is in hibernating state
<img width="1005" alt="Screenshot 2024-09-04 at 5 36 22 PM" src="https://github.com/user-attachments/assets/f5a47b1f-b99a-4af1-a437-757fb0a35225">
<img width="741" alt="Screenshot 2024-09-04 at 5 40 18 PM" src="https://github.com/user-attachments/assets/74b52803-e634-4c31-bae0-d4e48ad3a1ac">
<img width="548" alt="Screenshot 2024-09-04 at 5 41 54 PM" src="https://github.com/user-attachments/assets/21eb99b9-c30e-4943-a1ea-40ba4bbf0858">
