### PR TITLE
Add e2e tests for deploy action

### DIFF
--- a/.github/workflows/e2e/get_astro_env_info/action.yaml
+++ b/.github/workflows/e2e/get_astro_env_info/action.yaml
@@ -2,28 +2,28 @@ name: Get Astro Environment Info
 description: Get information about the Astro environment
 inputs:
   input_workspace_id:
-    description: The workspace ID via input
+    description: The workspace ID specified via user input
     required: true
   secret_workspace_id:
-    description: The workspace ID via secret
+    description: The workspace ID via pre configured secret
     required: true
   input_organization_id:
-    description: The organization ID via input
+    description: The organization ID specified via user input
     required: true
   secret_organization_id:
-    description: The organization ID via secret
+    description: The organization ID via pre configured secret
     required: true
   input_astro_api_token:
-    description: The Astronomer API token via input
+    description: The Astronomer API token specified via user input
     required: true
   secret_astro_api_token:
-    description: The Astronomer API token via secret
+    description: The Astronomer API token via pre configured secret
     required: true
   input_astronomer_host:
-    description: The Astronomer host via input
+    description: The Astronomer host specified via user input
     required: true
   secret_astronomer_host:
-    description: The Astronomer host via secret
+    description: The Astronomer host via pre configured secret
     required: true
 
 outputs:

--- a/.github/workflows/e2e/get_astro_env_info/action.yaml
+++ b/.github/workflows/e2e/get_astro_env_info/action.yaml
@@ -1,0 +1,74 @@
+name: Get Astro Environment Info
+description: Get information about the Astro environment
+inputs:
+  input_workspace_id:
+    description: The workspace ID via input
+    required: true
+  secret_workspace_id:
+    description: The workspace ID via secret
+    required: true
+  input_organization_id:
+    description: The organization ID via input
+    required: true
+  secret_organization_id:
+    description: The organization ID via secret
+    required: true
+  input_astro_api_token:
+    description: The Astronomer API token via input
+    required: true
+  secret_astro_api_token:
+    description: The Astronomer API token via secret
+    required: true
+  input_astronomer_host:
+    description: The Astronomer host via input
+    required: true
+  secret_astronomer_host:
+    description: The Astronomer host via secret
+    required: true
+
+outputs:
+  organization_id:
+    value: ${{ steps.get-info.outputs.ORGANIZATION_ID }}
+  workspace_id:
+    value: ${{ steps.get-info.outputs.WORKSPACE_ID }}
+  astronomer_host:
+    value: ${{ steps.get-info.outputs.ASTRONOMER_HOST }}
+  astro_api_token:
+    value: ${{ steps.get-info.outputs.ASTRO_API_TOKEN }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get info from inputs or secrets
+      shell: bash
+      id: get-info
+      run: |
+        if [ "${{ inputs.input_workspace_id }}" != "" ]; then
+          echo "Using provided workspace_id"
+          echo "WORKSPACE_ID=${{ inputs.input_workspace_id }}" >> $GITHUB_OUTPUT
+        else
+          echo "WORKSPACE_ID=${{ inputs.secret_workspace_id }}" >> $GITHUB_OUTPUT
+        fi
+
+        if [ "${{ inputs.input_organization_id }}" != "" ]; then
+          echo "Using provided org_id"
+          echo "ORGANIZATION_ID=${{ inputs.input_organization_id }}" >> $GITHUB_OUTPUT
+        else
+          echo "ORGANIZATION_ID=${{ inputs.secret_organization_id }}" >> $GITHUB_OUTPUT
+        fi
+
+        if [ "${{ inputs.input_astronomer_host }}" != "" ]; then
+          echo "Using provided astronomer_host"
+          echo "ASTRONOMER_HOST=${{ inputs.input_astronomer_host }}" >> $GITHUB_OUTPUT
+        else
+          echo "ASTRONOMER_HOST=${{ inputs.secret_astronomer_host }}" >> $GITHUB_OUTPUT
+        fi
+
+        if [ "${{ inputs.input_astro_api_token }}" != "" ]; then
+          echo "Using provided token"
+          echo "ASTRO_API_TOKEN=${{ inputs.input_astro_api_token }}" >> $GITHUB_OUTPUT
+          echo "ASTRO_API_TOKEN=${{ inputs.input_astro_api_token }}" >> $GITHUB_ENV
+        else
+          echo "ASTRO_API_TOKEN=${{ inputs.secret_astro_api_token }}" >> $GITHUB_OUTPUT
+          echo "ASTRO_API_TOKEN=${{ inputs.secret_astro_api_token }}" >> $GITHUB_ENV
+        fi

--- a/.github/workflows/e2e/get_deployment_info/action.yaml
+++ b/.github/workflows/e2e/get_deployment_info/action.yaml
@@ -1,0 +1,43 @@
+name: Get Deployment Info
+description: Get deployment info from Astronomer API
+inputs:
+  deployment_id:
+    description: The deployment ID
+    required: true
+  organization_id:
+    description: The organization ID
+    required: true
+  astro_api_token:
+    description: The Astronomer API token
+    required: true
+  astronomer_host:
+    description: The Astronomer host
+    required: true
+  expected_status_code:
+    description: The expected status code
+    default: 200
+
+outputs:
+  desired_dag_tarball_version:
+    description: The desired DAG tarball version
+    value: ${{ steps.get-deployment-info.outputs.desired_dag_tarball_version }}
+  desired_image_version:
+    description: The image version
+    value: ${{ steps.get-deployment-info.outputs.desired_image_version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Deployment Info
+      id: get-deployment-info
+      shell: bash
+      run: |
+        STATUS_CODE=$(curl -s -w "%{http_code}" -o response.json -H "Authorization: Bearer ${{ inputs.astro_api_token }}" "https://api.${{ inputs.astronomer_host }}/v1alpha1/organizations/${{ inputs.organization_id }}/deployments/${{ inputs.deployment_id }}")
+        if [[ $STATUS_CODE -ne ${{ inputs.expected_status_code }} ]]; then
+          echo "Failed to get expected status code from GET Deployment API. Status code: $STATUS_CODE"
+          exit 1
+        fi
+        desired_dag_tarball_version=$(cat response.json | jq -r '.desiredDagTarballVersion')
+        desired_image_version=$(cat response.json | jq -r '.desiredImageVersion')
+        echo "desired_dag_tarball_version=$desired_dag_tarball_version" >> $GITHUB_OUTPUT
+        echo "desired_image_version=$desired_image_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e/validate_deployment/action.yaml
+++ b/.github/workflows/e2e/validate_deployment/action.yaml
@@ -1,4 +1,4 @@
-name: Validate Deployment
+name: Validate Deployment Deploy Versions
 description: Validate deployment info from Astronomer API
 
 inputs:

--- a/.github/workflows/e2e/validate_deployment/action.yaml
+++ b/.github/workflows/e2e/validate_deployment/action.yaml
@@ -1,0 +1,45 @@
+name: Validate Deployment
+description: Validate deployment info from Astronomer API
+
+inputs:
+  is_dag_only_deploy:
+    description: Whether the deploy operation was DAG-only
+    default: false
+  dag_tarball_version_before:
+    description: The desired DAG tarball version before the test
+    required: true
+  image_version_before:
+    description: The image version before the test
+    required: true
+  dag_tarball_version_after:
+    description: The desired DAG tarball version after the test
+    required: true
+  image_version_after:
+    description: The image version after the test
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Deployment
+      id: validate-deployment
+      shell: bash
+      run: |
+
+        # If it's dag only deploy then validate that only desiredDagTarballVersion was updated
+        if [[ "${{ inputs.is_dag_only_deploy }}" == "true" ]]; then
+          if [[ "${{ inputs.dag_tarball_version_before }}" != "${{ inputs.dag_tarball_version_after }}" && "${{ inputs.image_version_before }}" == "${{ inputs.image_version_after }}" ]]; then  
+            echo "Deploy Action validation succeeded: desiredDagTarballVersion only updated"
+            exit 0
+          fi
+          echo "Deploy Action validation failed"
+          exit 1
+        fi
+
+        # If it's not dag only deploy then validate that both desiredDagTarballVersion and imageVersion were updated
+        if [[ "${{ inputs.dag_tarball_version_before }}" != "${{ inputs.dag_tarball_version_after }}" && "${{ inputs.image_version_before }}" != "${{ inputs.image_version_after }}" ]]; then
+          echo "Deploy Action validation succeeded: desiredDagTarballVersion and imageVersion updated"
+          exit 0
+        fi
+        echo "Deploy Action validation failed: neither desiredDagTarballVersion or imageVersion were updated after the test"
+        exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - e2e-tests
   workflow_dispatch:
 
 # To ensure that only one workflow runs at a time, and other wait for previous workflow to finish

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - e2e-tests
   workflow_dispatch:
 
 # To ensure that only one workflow runs at a time, and other wait for previous workflow to finish

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,14 +6,53 @@ on:
       - main
       - e2e-tests
   workflow_dispatch:
+    inputs:
+      workspace_id:
+        description: "Workspace ID"
+        required: false
+        default: ""
+      org_id:
+        description: "Organization ID"
+        required: false
+        default: ""
+      astronomer_host:
+        description: "Astronomer Host"
+        required: false
+        default: ""
+      token:
+        description: "API Token"
+        required: false
+        default: ""
 
 env:
   ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
 
 jobs:
+  redact-inputs:
+    name: Redact Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Redact Inputs
+        run: |
+
+          # add-mask will redact the value of the input, but will still log the value, 
+          # hence using a known workaround: https://github.com/actions/runner/issues/643
+          WORKSPACE_ID=$(jq -r '.inputs.workspace_id' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$WORKSPACE_ID
+          ORG_ID=$(jq -r '.inputs.org_id' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$ORG_ID
+          ASTRONOMER_HOST=$(jq -r '.inputs.astronomer_host' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$ASTRONOMER_HOST
+          TOKEN=$(jq -r '.inputs.token' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$TOKEN
+
   # Create test deployments would use the template files and generate deployments with unique names
   create-test-deployments:
     name: Create Deployment
+    needs: redact-inputs
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,6 +64,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+
       - name: Install dependencies
         run: |
 
@@ -33,8 +85,8 @@ jobs:
           sudo apt install yq -y
 
           curl -sSL https://install.astronomer.io | sudo bash -s
-          astro context switch ${{ secrets.ASTRONOMER_HOST }}
-          astro workspace switch ${{ secrets.WORKSPACE_ID }}
+          astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
+          astro workspace switch ${{ steps.get-astro-env-info.outputs.workspace_id }}
 
           # Generate a random test_uid and set it as an environment variable, so we can append it to the deployment name
           test_uid=$(uuidgen)
@@ -58,7 +110,7 @@ jobs:
   dag-deploy-test:
     name: DAG Deploy Test
     runs-on: ubuntu-latest
-    needs: create-test-deployments
+    needs: [create-test-deployments]
     strategy:
       matrix:
         deployment_id:
@@ -69,6 +121,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
 
       - name: Mock git commands
         run: |
@@ -83,22 +148,22 @@ jobs:
           curl -sSL https://install.astronomer.io | sudo bash -s
 
       - name: Set CLI context
-        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+        run: astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Get Deployment Info Before Test
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Deploy to Astro
         uses: ./
         with:
           deployment-id: ${{ matrix.deployment_id }}
-          workspace: ${{ secrets.WORKSPACE_ID }}
+          workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           parse: true
           root-folder: e2e-setup/astro-project
 
@@ -107,9 +172,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
@@ -135,6 +200,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+
       - name: Install dependencies
         run: |
 
@@ -144,23 +222,24 @@ jobs:
           curl -sSL https://install.astronomer.io | sudo bash -s
 
       - name: Set CLI context
-        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+        run: astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Get Deployment Info Before Test
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Run Pytest
         uses: ./
         with:
           deployment-id: ${{ matrix.deployment_id }}
-          workspace: ${{ secrets.WORKSPACE_ID }}
+          workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           pytest: true
+          deploy-image: true
           root-folder: e2e-setup/astro-project
 
       - name: Get Deployment Info After Test
@@ -168,9 +247,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
@@ -195,6 +274,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+
       - name: Install dependencies
         run: |
 
@@ -207,23 +299,24 @@ jobs:
         run: cd e2e-setup/astro-project && docker build -t custom-image:latest .
 
       - name: Set CLI context
-        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+        run: astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Get Deployment Info Before Test
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Deploy to Astro
         uses: ./
         with:
           deployment-id: ${{ matrix.deployment_id }}
-          workspace: ${{ secrets.WORKSPACE_ID }}
+          workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           image-name: custom-image:latest
+          deploy-image: true
           root-folder: e2e-setup/astro-project
 
       - name: Get Deployment Info After Test
@@ -231,9 +324,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ matrix.deployment_id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
@@ -247,7 +340,7 @@ jobs:
   deployment-preview-test:
     name: Deployment Preview Test
     runs-on: ubuntu-latest
-    needs: create-test-deployments
+    needs: [create-test-deployments]
     strategy:
       matrix:
         deployment_id:
@@ -259,6 +352,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+
       - name: Install dependencies
         id: install-pre-reqs
         run: |
@@ -269,14 +375,14 @@ jobs:
           curl -sSL https://install.astronomer.io | sudo bash -s
 
       - name: Set CLI context
-        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+        run: astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Create Deployment Preview
         id: create-deployment-preview
         uses: ./
         with:
           deployment-id: ${{ matrix.deployment_id }}
-          workspace: ${{ secrets.WORKSPACE_ID }}
+          workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           action: create-deployment-preview
           preview-name: test-preview-${{ matrix.deployment_id }}
           root-folder: e2e-setup/astro-project
@@ -290,9 +396,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate Deploy Action
         id: validate-deployment-preview-create
@@ -308,9 +414,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Deploy to Deployment Preview
         id: deployment-preview-deploy
@@ -320,6 +426,7 @@ jobs:
           workspace: ${{ secrets.WORKSPACE_ID }}
           action: deploy-deployment-preview
           root-folder: e2e-setup/astro-project
+          deploy-image: true
           preview-name: test-preview-${{ matrix.deployment_id }}
 
       - name: Get Deployment Info After Test
@@ -327,9 +434,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ steps.deployment-preview-deploy.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate Deploy Action
         id: validate-deployment-preview-deploy
@@ -350,9 +457,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: DAG Deploy to Astro
         id: deployment-preview-dag-deploy
@@ -369,9 +476,9 @@ jobs:
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
           deployment_id: ${{ steps.deployment-preview-dag-deploy.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
       - name: Validate DAG Deploy Action
         id: validate-dag-deploy-action
@@ -402,9 +509,9 @@ jobs:
         with:
           expected_status_code: 404
           deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
-          organization_id: ${{ secrets.ORGANIZATION_ID }}
-          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
-          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          organization_id: ${{ steps.get-astro-env-info.outputs.organization_id }}
+          astro_api_token: ${{ steps.get-astro-env-info.outputs.astro_api_token }}
+          astronomer_host: ${{ steps.get-astro-env-info.outputs.astronomer_host }}
 
   delete-test-deployments:
     name: Delete Deployment
@@ -423,11 +530,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get Astro Environment Info
+        id: get-astro-env-info
+        uses: ./.github/workflows/e2e/get_astro_env_info
+        with:
+          input_workspace_id: ${{ github.event.inputs.workspace_id }}
+          input_organization_id: ${{ github.event.inputs.org_id }}
+          input_astronomer_host: ${{ github.event.inputs.astronomer_host }}
+          input_astro_api_token: ${{ github.event.inputs.token }}
+          secret_workspace_id: ${{ secrets.WORKSPACE_ID }}
+          secret_organization_id: ${{ secrets.ORGANIZATION_ID }}
+          secret_astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+          secret_astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+
       - name: Install Astro CLI and set context
         run: |
           curl -sSL https://install.astronomer.io | sudo bash -s
-          astro context switch ${{ secrets.ASTRONOMER_HOST }}
-          astro workspace switch ${{ secrets.WORKSPACE_ID }}
+          astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}
+          astro workspace switch ${{ steps.get-astro-env-info.outputs.workspace_id }}
 
       - name: Delete Deployment
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,342 @@
+name: E2E Tests for Astro Deploy Action
+
+on:
+  push:
+    branches:
+      - main
+      - e2e-tests
+  workflow_dispatch:
+
+# To ensure that only one workflow runs at a time, and other wait for previous workflow to finish
+concurrency:
+  group: e2e-tests
+  cancel-in-progress: false
+
+env:
+  ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
+  ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
+  WORKSPACE_ID: ${{ secrets.WORKSPACE_ID }}
+  DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
+  ASTRONOMER_HOST: ${{ secrets.ASTRONOMER_HOST }}
+
+jobs:
+  dag-deploy-test:
+    name: DAG Deploy Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+
+          sudo apt-get install jq
+          # we need to pre-install the CLI to set the context
+          curl -sSL https://install.astronomer.io | sudo bash -s
+
+      - name: Mock git commands
+        run: |
+          mv e2e-setup/mocks/git.sh /usr/local/bin/git
+          chmod +x /usr/local/bin/git
+
+      - name: Set CLI context
+        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Get Deployment Info Before Test
+        id: get-deployment-before
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Deploy to Astro
+        uses: ./
+        with:
+          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          parse: true
+          root-folder: e2e-setup/astro-project
+
+      - name: Get Deployment Info After Test
+        id: get-deployment-after
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate Deploy Action
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          is_dag_only_deploy: true
+          dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
+          image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
+          image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+
+  pytests-test:
+    name: Pytest Test
+    runs-on: ubuntu-latest
+    needs: dag-deploy-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+
+          sudo apt-get install jq
+
+          # we need to pre-install the CLI to set the context
+          curl -sSL https://install.astronomer.io | sudo bash -s
+
+      - name: Set CLI context
+        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Get Deployment Info Before Test
+        id: get-deployment-before
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Run Pytest
+        uses: ./
+        with:
+          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          pytest: true
+          root-folder: e2e-setup/astro-project
+
+      - name: Get Deployment Info After Test
+        id: get-deployment-after
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate Deploy Action
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
+          image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
+          image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+
+  custom-docker-image-test:
+    name: Custom Docker Image Test
+    runs-on: ubuntu-latest
+    needs: pytests-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+
+          sudo apt-get install jq
+
+          # we need to pre-install the CLI to set the context
+          curl -sSL https://install.astronomer.io | sudo bash -s
+
+      - name: Build Docker image
+        run: cd e2e-setup/astro-project && docker build -t custom-image:latest .
+
+      - name: Set CLI context
+        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Get Deployment Info Before Test
+        id: get-deployment-before
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Deploy to Astro
+        uses: ./
+        with:
+          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          image-name: custom-image:latest
+          root-folder: e2e-setup/astro-project
+
+      - name: Get Deployment Info After Test
+        id: get-deployment-after
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate Deploy Action
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
+          image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desiredDagTarballVersion }}
+          image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+
+  # these tests can run in parallel since it operates on a different deployment, so it won't interfere with the above tests
+  deployment-preview-test:
+    name: Deployment Preview Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        id: install-pre-reqs
+        run: |
+
+          sudo apt-get install jq
+
+          # we need to pre-install the CLI to set the context
+          curl -sSL https://install.astronomer.io | sudo bash -s
+
+          # Generate a random preview_id and set it as an environment variable
+          preview_id=$(( RANDOM % 1000 ))
+          echo "preview_id=$preview_id" >> $GITHUB_ENV
+
+      - name: Set CLI context
+        run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Create Deployment Preview
+        id: create-deployment-preview
+        uses: ./
+        with:
+          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          action: create-deployment-preview
+          preview-name: test-preview-${{ env.preview_id }}
+          root-folder: e2e-setup/astro-project
+
+      - name: Get Deployment Info After Test
+        id: get-deployment-after-create-preview
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate Deploy Action
+        id: validate-deployment-preview-create
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          dag_tarball_version_before: ""
+          image_version_before: "12.1.0"
+          dag_tarball_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_dag_tarball_version }}
+          image_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_image_version }}
+
+      - name: Get Deployment Info Before Test
+        id: get-deployment-before-deploy
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Deploy to Deployment Preview
+        id: deployment-preview-deploy
+        uses: ./
+        with:
+          deployment-id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          action: deploy-deployment-preview
+          root-folder: e2e-setup/astro-project
+          preview-name: test-preview-${{ env.preview_id }}
+
+      - name: Get Deployment Info After Test
+        id: get-deployment-after-deploy-preview
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ steps.deployment-preview-deploy.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate Deploy Action
+        id: validate-deployment-preview-deploy
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          dag_tarball_version_before: ${{ steps.get-deployment-before-deploy.outputs.desired_dag_tarball_version }}
+          image_version_before: ${{ steps.get-deployment-before-deploy.outputs.desired_image_version }}
+          dag_tarball_version_after: ${{ steps.get-deployment-after-deploy-preview.outputs.desired_dag_tarball_version }}
+          image_version_after: ${{ steps.get-deployment-after-deploy-preview.outputs.desired_image_version }}
+
+      - name: Mock git commands for DAG Deploy
+        run: |
+          mv e2e-setup/mocks/git.sh /usr/local/bin/git
+          chmod +x /usr/local/bin/git
+
+      - name: Get Deployment Info Before DAG Deploy Test
+        id: get-deployment-before-dag-deploy
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: DAG Deploy to Astro
+        id: deployment-preview-dag-deploy
+        uses: ./
+        with:
+          deployment-id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          parse: true
+          root-folder: e2e-setup/astro-project
+          preview-name: test-preview-${{ env.preview_id }}
+
+      - name: Get Deployment Info After DAG Deploy Test
+        id: get-deployment-after-dag-deploy
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          deployment_id: ${{ steps.deployment-preview-dag-deploy.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+      - name: Validate DAG Deploy Action
+        id: validate-dag-deploy-action
+        uses: ./.github/workflows/e2e/validate_deployment
+        with:
+          is_dag_only_deploy: true
+          dag_tarball_version_before: ${{ steps.get-deployment-before-dag-deploy.outputs.desired_dag_tarball_version }}
+          image_version_before: ${{ steps.get-deployment-before-dag-deploy.outputs.desired_image_version }}
+          dag_tarball_version_after: ${{ steps.get-deployment-after-dag-deploy.outputs.desired_dag_tarball_version }}
+          image_version_after: ${{ steps.get-deployment-after-dag-deploy.outputs.desired_image_version }}
+
+      - name: Delete Deployment Preview
+        id: delete-deployment-preview
+        # ensure that we always try delete the deployment preview even if the previous steps fail
+        if: always()
+        uses: ./
+        with:
+          deployment-id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          workspace: ${{ secrets.WORKSPACE_ID }}
+          action: delete-deployment-preview
+          preview-name: test-preview-${{ env.preview_id }}
+
+      - name: Validate Deployment Preview Deletion
+        id: validate-deployment-preview-deletion
+        # ensure that we always try delete the deployment preview even if the previous steps fail
+        if: always()
+        uses: ./.github/workflows/e2e/get_deployment_info
+        with:
+          expected_status_code: 404
+          deployment_id: ${{ steps.create-deployment-preview.outputs.preview-id }}
+          organization_id: ${{ secrets.ORGANIZATION_ID }}
+          astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
+          astronomer_host: ${{ secrets.ASTRONOMER_HOST }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,25 +7,73 @@ on:
       - e2e-tests
   workflow_dispatch:
 
-# To ensure that only one workflow runs at a time, and other wait for previous workflow to finish
-concurrency:
-  group: e2e-tests
-  cancel-in-progress: false
-
 env:
   ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
-  ORGANIZATION_ID: ${{ secrets.ORGANIZATION_ID }}
-  WORKSPACE_ID: ${{ secrets.WORKSPACE_ID }}
-  DEPLOYMENT_ID: ${{ secrets.DEPLOYMENT_ID }}
-  ASTRONOMER_HOST: ${{ secrets.ASTRONOMER_HOST }}
 
 jobs:
-  dag-deploy-test:
-    name: DAG Deploy Test
+  # Create test deployments would use the template files and generate deployments with unique names
+  create-test-deployments:
+    name: Create Deployment
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deployment: [deployment-hibernate.yaml, deployment.yaml]
+    outputs:
+      DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.DEPLOYMENT_ID }}
+      HIBERNATE_DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.HIBERNATE_DEPLOYMENT_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+
+          sudo add-apt-repository ppa:rmescandon/yq
+          sudo apt update
+          sudo apt install yq -y
+
+          curl -sSL https://install.astronomer.io | sudo bash -s
+          astro context switch ${{ secrets.ASTRONOMER_HOST }}
+          astro workspace switch ${{ secrets.WORKSPACE_ID }}
+
+          # Generate a random test_uid and set it as an environment variable, so we can append it to the deployment name
+          test_uid=$(uuidgen)
+          echo "test_uid=$test_uid" >> $GITHUB_ENV
+
+      - name: Create Deployment
+        id: create-deployment
+        run: |
+
+          # Update the deployment name to maintain uniqueness
+          sed -i "s|  name:.*|  name: deploy-action-e2e-${{ env.test_uid }}|g"  e2e-setup/deployment-templates/${{ matrix.deployment }}
+
+          DEPLOYMENT_ID=$(astro deployment create --deployment-file e2e-setup/deployment-templates/${{ matrix.deployment }} | yq e '.deployment.metadata.deployment_id' -)
+          if [[ "${{ matrix.deployment }}" == "deployment.yaml" ]]; then
+            echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+          else
+            echo "HIBERNATE_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+          fi
+
+  # DAG Deploy test would test the DAG only deploy functionality in deploy action
+  dag-deploy-test:
+    name: DAG Deploy Test
+    runs-on: ubuntu-latest
+    needs: create-test-deployments
+    strategy:
+      matrix:
+        deployment_id:
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Mock git commands
+        run: |
+          mv e2e-setup/mocks/git.sh /usr/local/bin/git
+          chmod +x /usr/local/bin/git
 
       - name: Install dependencies
         run: |
@@ -34,11 +82,6 @@ jobs:
           # we need to pre-install the CLI to set the context
           curl -sSL https://install.astronomer.io | sudo bash -s
 
-      - name: Mock git commands
-        run: |
-          mv e2e-setup/mocks/git.sh /usr/local/bin/git
-          chmod +x /usr/local/bin/git
-
       - name: Set CLI context
         run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
 
@@ -46,7 +89,7 @@ jobs:
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -54,7 +97,7 @@ jobs:
       - name: Deploy to Astro
         uses: ./
         with:
-          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ secrets.WORKSPACE_ID }}
           parse: true
           root-folder: e2e-setup/astro-project
@@ -63,7 +106,7 @@ jobs:
         id: get-deployment-after
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -80,7 +123,14 @@ jobs:
   pytests-test:
     name: Pytest Test
     runs-on: ubuntu-latest
-    needs: dag-deploy-test
+    needs: [dag-deploy-test, create-test-deployments]
+    strategy:
+      matrix:
+        deployment_id:
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -100,7 +150,7 @@ jobs:
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -108,7 +158,7 @@ jobs:
       - name: Run Pytest
         uses: ./
         with:
-          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ secrets.WORKSPACE_ID }}
           pytest: true
           root-folder: e2e-setup/astro-project
@@ -117,7 +167,7 @@ jobs:
         id: get-deployment-after
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -133,7 +183,14 @@ jobs:
   custom-docker-image-test:
     name: Custom Docker Image Test
     runs-on: ubuntu-latest
-    needs: pytests-test
+    needs: [pytests-test, create-test-deployments]
+    strategy:
+      matrix:
+        deployment_id:
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -156,7 +213,7 @@ jobs:
         id: get-deployment-before
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -164,7 +221,7 @@ jobs:
       - name: Deploy to Astro
         uses: ./
         with:
-          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ secrets.WORKSPACE_ID }}
           image-name: custom-image:latest
           root-folder: e2e-setup/astro-project
@@ -173,7 +230,7 @@ jobs:
         id: get-deployment-after
         uses: ./.github/workflows/e2e/get_deployment_info
         with:
-          deployment_id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment_id: ${{ matrix.deployment_id }}
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
@@ -186,10 +243,18 @@ jobs:
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desiredDagTarballVersion }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
 
-  # these tests can run in parallel since it operates on a different deployment, so it won't interfere with the above tests
+  # Deployment preview tests can run in parallel to above tests since it operates on a different deployment, so it won't interfere with the above tests
   deployment-preview-test:
     name: Deployment Preview Test
     runs-on: ubuntu-latest
+    needs: create-test-deployments
+    strategy:
+      matrix:
+        deployment_id:
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -203,10 +268,6 @@ jobs:
           # we need to pre-install the CLI to set the context
           curl -sSL https://install.astronomer.io | sudo bash -s
 
-          # Generate a random preview_id and set it as an environment variable
-          preview_id=$(( RANDOM % 1000 ))
-          echo "preview_id=$preview_id" >> $GITHUB_ENV
-
       - name: Set CLI context
         run: astro context switch ${{ secrets.ASTRONOMER_HOST }}
 
@@ -214,11 +275,15 @@ jobs:
         id: create-deployment-preview
         uses: ./
         with:
-          deployment-id: ${{ secrets.DEPLOYMENT_ID }}
+          deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ secrets.WORKSPACE_ID }}
           action: create-deployment-preview
-          preview-name: test-preview-${{ env.preview_id }}
+          preview-name: test-preview-${{ matrix.deployment_id }}
           root-folder: e2e-setup/astro-project
+          # TODO: allow copying airflow resources, once we add wait in the deploy action for deployment preview to be healthy
+          copy-connections: false
+          copy-airflow-variables: false
+          copy-pools: false
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-create-preview
@@ -255,7 +320,7 @@ jobs:
           workspace: ${{ secrets.WORKSPACE_ID }}
           action: deploy-deployment-preview
           root-folder: e2e-setup/astro-project
-          preview-name: test-preview-${{ env.preview_id }}
+          preview-name: test-preview-${{ matrix.deployment_id }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-deploy-preview
@@ -297,7 +362,7 @@ jobs:
           workspace: ${{ secrets.WORKSPACE_ID }}
           parse: true
           root-folder: e2e-setup/astro-project
-          preview-name: test-preview-${{ env.preview_id }}
+          preview-name: test-preview-${{ matrix.deployment_id }}
 
       - name: Get Deployment Info After DAG Deploy Test
         id: get-deployment-after-dag-deploy
@@ -327,7 +392,7 @@ jobs:
           deployment-id: ${{ steps.create-deployment-preview.outputs.preview-id }}
           workspace: ${{ secrets.WORKSPACE_ID }}
           action: delete-deployment-preview
-          preview-name: test-preview-${{ env.preview_id }}
+          preview-name: test-preview-${{ matrix.deployment_id }}
 
       - name: Validate Deployment Preview Deletion
         id: validate-deployment-preview-deletion
@@ -340,3 +405,31 @@ jobs:
           organization_id: ${{ secrets.ORGANIZATION_ID }}
           astro_api_token: ${{ secrets.ASTRO_API_TOKEN }}
           astronomer_host: ${{ secrets.ASTRONOMER_HOST }}
+
+  delete-test-deployments:
+    name: Delete Deployment
+    runs-on: ubuntu-latest
+    needs:
+      [
+        create-test-deployments,
+        dag-deploy-test,
+        pytests-test,
+        custom-docker-image-test,
+        deployment-preview-test,
+      ]
+    # ensure that we always try delete the deployment even if any of the tests fail
+    if: always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Astro CLI and set context
+        run: |
+          curl -sSL https://install.astronomer.io | sudo bash -s
+          astro context switch ${{ secrets.ASTRONOMER_HOST }}
+          astro workspace switch ${{ secrets.WORKSPACE_ID }}
+
+      - name: Delete Deployment
+        run: |
+          astro deployment delete -f ${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}
+          astro deployment delete -f ${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}

--- a/action.yaml
+++ b/action.yaml
@@ -163,6 +163,8 @@ runs:
           # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml
 
+          # TODO: we need to add wait for deployment to be created, otherwise operation to copy airflow resources like connection is flaky if webserver is not up by then
+
           # Get final Deployment ID
           echo "FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)" >> $GITHUB_OUTPUT
 

--- a/action.yaml
+++ b/action.yaml
@@ -361,6 +361,8 @@ runs:
           else
             echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
           fi
+        else
+          echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
       id: development-mode

--- a/e2e-setup/README.md
+++ b/e2e-setup/README.md
@@ -1,0 +1,31 @@
+# End-to-End Setup
+
+This folder contains the necessary setup for running end-to-end tests for the Astro Deploy Action. Below is the folder structure and a brief description of the contents at the first level.
+
+## Folder Structure
+
+e2e-setup/
+├── astro-project/
+├── deployment-templates/
+│ ├── deployment-hibernate.yaml
+│ └── deployment.yaml
+├── mocks/
+│ └── git.sh
+
+### astro-project
+
+Astro project folder contains a basic airflow project initialized via Astro CLI, which will deployed as part of tests via deploy action
+
+### deployment-templates
+
+Deployment templates contains the basic templates used by e2e tests to create required deployments against which tests would be executed
+
+- **deployment-hibernate.yaml**: Template for creating a deployment with forever hibernation schedules.
+- **deployment.yaml**: Template for creating a standard deployment.
+
+### mocks
+
+mocks folder contain script or logic to mock different part of the logic during e2e tests execution.
+As of now it only contain `git.sh` which would replace the git cli so that in deploy action we could mock that only dags file has changed during dag deploy tests.
+
+- **git.sh**: Script to mock git commands for simulating DAGs-only deploy scenarios.

--- a/e2e-setup/README.md
+++ b/e2e-setup/README.md
@@ -2,6 +2,8 @@
 
 This folder contains the necessary setup for running end-to-end tests for the Astro Deploy Action. Below is the folder structure and a brief description of the contents at the first level.
 
+The E2E tests could be triggered automatically when a new commit is pushed to main, or it could be manually triggered. E2E setup also supports specifying custom Astro environment, organization id, workspace id or organization API token to run these tests when triggered manually from Actions page (if not specified the test setup will pick the default values set as secrets).
+
 ## Folder Structure
 
 e2e-setup/

--- a/e2e-setup/astro-project/.astro/config.yaml
+++ b/e2e-setup/astro-project/.astro/config.yaml
@@ -1,0 +1,2 @@
+project:
+    name: astro-project

--- a/e2e-setup/astro-project/.astro/dag_integrity_exceptions.txt
+++ b/e2e-setup/astro-project/.astro/dag_integrity_exceptions.txt
@@ -1,0 +1,1 @@
+# Add dag files to exempt from parse test below. ex: dags/<test-file>

--- a/e2e-setup/astro-project/.astro/test_dag_integrity_default.py
+++ b/e2e-setup/astro-project/.astro/test_dag_integrity_default.py
@@ -1,0 +1,141 @@
+"""Test the validity of all DAGs. **USED BY DEV PARSE COMMAND DO NOT EDIT**"""
+
+from contextlib import contextmanager
+import logging
+import os
+
+import pytest
+
+from airflow.models import DagBag, Variable, Connection
+from airflow.hooks.base import BaseHook
+from airflow.utils.db import initdb
+
+# init airflow database
+initdb()
+
+# The following code patches errors caused by missing OS Variables, Airflow Connections, and Airflow Variables
+
+
+# =========== MONKEYPATCH BaseHook.get_connection() ===========
+def basehook_get_connection_monkeypatch(key: str, *args, **kwargs):
+    print(
+        f"Attempted to fetch connection during parse returning an empty Connection object for {key}"
+    )
+    return Connection(key)
+
+
+BaseHook.get_connection = basehook_get_connection_monkeypatch
+# # =========== /MONKEYPATCH BASEHOOK.GET_CONNECTION() ===========
+
+
+# =========== MONKEYPATCH OS.GETENV() ===========
+def os_getenv_monkeypatch(key: str, *args, **kwargs):
+    default = None
+    if args:
+        default = args[0]  # os.getenv should get at most 1 arg after the key
+    if kwargs:
+        default = kwargs.get(
+            "default", None
+        )  # and sometimes kwarg if people are using the sig
+
+    env_value = os.environ.get(key, None)
+
+    if env_value:
+        return env_value  # if the env_value is set, return it
+    if (
+        key == "JENKINS_HOME" and default is None
+    ):  # fix https://github.com/astronomer/astro-cli/issues/601
+        return None
+    if default:
+        return default  # otherwise return whatever default has been passed
+    return f"MOCKED_{key.upper()}_VALUE"  # if absolutely nothing has been passed - return the mocked value
+
+
+os.getenv = os_getenv_monkeypatch
+# # =========== /MONKEYPATCH OS.GETENV() ===========
+
+# =========== MONKEYPATCH VARIABLE.GET() ===========
+
+
+class magic_dict(dict):
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+
+    def __getitem__(self, key):
+        return {}.get(key, "MOCKED_KEY_VALUE")
+
+
+_no_default = object()  # allow falsey defaults
+
+
+def variable_get_monkeypatch(key: str, default_var=_no_default, deserialize_json=False):
+    print(
+        f"Attempted to get Variable value during parse, returning a mocked value for {key}"
+    )
+
+    if default_var is not _no_default:
+        return default_var
+    if deserialize_json:
+        return magic_dict()
+    return "NON_DEFAULT_MOCKED_VARIABLE_VALUE"
+
+
+Variable.get = variable_get_monkeypatch
+# # =========== /MONKEYPATCH VARIABLE.GET() ===========
+
+
+@contextmanager
+def suppress_logging(namespace):
+    """
+    Suppress logging within a specific namespace to keep tests "clean" during build
+    """
+    logger = logging.getLogger(namespace)
+    old_value = logger.disabled
+    logger.disabled = True
+    try:
+        yield
+    finally:
+        logger.disabled = old_value
+
+
+def get_import_errors():
+    """
+    Generate a tuple for import errors in the dag bag, and include DAGs without errors.
+    """
+    with suppress_logging("airflow"):
+        dag_bag = DagBag(include_examples=False)
+
+        def strip_path_prefix(path):
+            return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
+
+        # Initialize an empty list to store the tuples
+        result = []
+
+        # Iterate over the items in import_errors
+        for k, v in dag_bag.import_errors.items():
+            result.append((strip_path_prefix(k), v.strip()))
+
+        # Check if there are DAGs without errors
+        for file_path in dag_bag.dags:
+            # Check if the file_path is not in import_errors, meaning no errors
+            if file_path not in dag_bag.import_errors:
+                result.append((strip_path_prefix(file_path), "No import errors"))
+
+        return result
+
+
+@pytest.mark.parametrize(
+    "rel_path, rv", get_import_errors(), ids=[x[0] for x in get_import_errors()]
+)
+def test_file_imports(rel_path, rv):
+    """Test for import errors on a file"""
+    if os.path.exists(".astro/dag_integrity_exceptions.txt"):
+        with open(".astro/dag_integrity_exceptions.txt", "r") as f:
+            exceptions = f.readlines()
+    print(f"Exceptions: {exceptions}")
+    if (rv != "No import errors") and rel_path not in exceptions:
+        # If rv is not "No import errors," consider it a failed test
+        raise Exception(f"{rel_path} failed to import with message \n {rv}")
+    else:
+        # If rv is "No import errors," consider it a passed test
+        print(f"{rel_path} passed the import test")

--- a/e2e-setup/astro-project/.dockerignore
+++ b/e2e-setup/astro-project/.dockerignore
@@ -1,0 +1,8 @@
+astro
+.git
+.env
+airflow_settings.yaml
+logs/
+.venv
+airflow.db
+airflow.cfg

--- a/e2e-setup/astro-project/.gitignore
+++ b/e2e-setup/astro-project/.gitignore
@@ -1,0 +1,11 @@
+.git
+.env
+.DS_Store
+airflow_settings.yaml
+__pycache__/
+astro
+.venv
+airflow-webserver.pid
+webserver_config.py
+airflow.cfg
+airflow.db

--- a/e2e-setup/astro-project/Dockerfile
+++ b/e2e-setup/astro-project/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/astronomer/astro-runtime:12.1.0

--- a/e2e-setup/astro-project/README.md
+++ b/e2e-setup/astro-project/README.md
@@ -1,0 +1,48 @@
+Overview
+========
+
+Welcome to Astronomer! This project was generated after you ran 'astro dev init' using the Astronomer CLI. This readme describes the contents of the project, as well as how to run Apache Airflow on your local machine.
+
+Project Contents
+================
+
+Your Astro project contains the following files and folders:
+
+- dags: This folder contains the Python files for your Airflow DAGs. By default, this directory includes one example DAG:
+    - `example_astronauts`: This DAG shows a simple ETL pipeline example that queries the list of astronauts currently in space from the Open Notify API and prints a statement for each astronaut. The DAG uses the TaskFlow API to define tasks in Python, and dynamic task mapping to dynamically print a statement for each astronaut. For more on how this DAG works, see our [Getting started tutorial](https://www.astronomer.io/docs/learn/get-started-with-airflow).
+- Dockerfile: This file contains a versioned Astro Runtime Docker image that provides a differentiated Airflow experience. If you want to execute other commands or overrides at runtime, specify them here.
+- include: This folder contains any additional files that you want to include as part of your project. It is empty by default.
+- packages.txt: Install OS-level packages needed for your project by adding them to this file. It is empty by default.
+- requirements.txt: Install Python packages needed for your project by adding them to this file. It is empty by default.
+- plugins: Add custom or community plugins for your project to this file. It is empty by default.
+- airflow_settings.yaml: Use this local-only file to specify Airflow Connections, Variables, and Pools instead of entering them in the Airflow UI as you develop DAGs in this project.
+
+Deploy Your Project Locally
+===========================
+
+1. Start Airflow on your local machine by running 'astro dev start'.
+
+This command will spin up 4 Docker containers on your machine, each for a different Airflow component:
+
+- Postgres: Airflow's Metadata Database
+- Webserver: The Airflow component responsible for rendering the Airflow UI
+- Scheduler: The Airflow component responsible for monitoring and triggering tasks
+- Triggerer: The Airflow component responsible for triggering deferred tasks
+
+2. Verify that all 4 Docker containers were created by running 'docker ps'.
+
+Note: Running 'astro dev start' will start your project with the Airflow Webserver exposed at port 8080 and Postgres exposed at port 5432. If you already have either of those ports allocated, you can either [stop your existing Docker containers or change the port](https://www.astronomer.io/docs/astro/cli/troubleshoot-locally#ports-are-not-available-for-my-local-airflow-webserver).
+
+3. Access the Airflow UI for your local Airflow project. To do so, go to http://localhost:8080/ and log in with 'admin' for both your Username and Password.
+
+You should also be able to access your Postgres Database at 'localhost:5432/postgres'.
+
+Deploy Your Project to Astronomer
+=================================
+
+If you have an Astronomer account, pushing code to a Deployment on Astronomer is simple. For deploying instructions, refer to Astronomer documentation: https://www.astronomer.io/docs/astro/deploy-code/
+
+Contact
+=======
+
+The Astronomer CLI is maintained with love by the Astronomer team. To report a bug or suggest a change, reach out to our support.

--- a/e2e-setup/astro-project/dags/exampledag.py
+++ b/e2e-setup/astro-project/dags/exampledag.py
@@ -1,0 +1,100 @@
+"""
+## Astronaut ETL example DAG
+
+This DAG queries the list of astronauts currently in space from the
+Open Notify API and prints each astronaut's name and flying craft.
+
+There are two tasks, one to get the data from the API and save the results,
+and another to print the results. Both tasks are written in Python using
+Airflow's TaskFlow API, which allows you to easily turn Python functions into
+Airflow tasks, and automatically infer dependencies and pass data.
+
+The second task uses dynamic task mapping to create a copy of the task for
+each Astronaut in the list retrieved from the API. This list will change
+depending on how many Astronauts are in space, and the DAG will adjust
+accordingly each time it runs.
+
+For more explanation and getting started instructions, see our Write your
+first DAG tutorial: https://www.astronomer.io/docs/learn/get-started-with-airflow
+
+![Picture of the ISS](https://www.esa.int/var/esa/storage/images/esa_multimedia/images/2010/02/space_station_over_earth/10293696-3-eng-GB/Space_Station_over_Earth_card_full.jpg)
+"""
+
+from airflow import Dataset
+from airflow.decorators import dag, task
+from pendulum import datetime
+import requests
+
+
+# Define the basic parameters of the DAG, like schedule and start_date
+@dag(
+    start_date=datetime(2024, 1, 1),
+    schedule="@daily",
+    catchup=False,
+    doc_md=__doc__,
+    default_args={"owner": "Astro", "retries": 3},
+    tags=["example"],
+)
+def example_astronauts():
+    # Define tasks
+    @task(
+        # Define a dataset outlet for the task. This can be used to schedule downstream DAGs when this task has run.
+        outlets=[Dataset("current_astronauts")]
+    )  # Define that this task updates the `current_astronauts` Dataset
+    def get_astronauts(**context) -> list[dict]:
+        """
+        This task uses the requests library to retrieve a list of Astronauts
+        currently in space. The results are pushed to XCom with a specific key
+        so they can be used in a downstream pipeline. The task returns a list
+        of Astronauts to be used in the next task.
+        """
+        try:
+            r = requests.get("http://api.open-notify.org/astros.json")
+            r.raise_for_status()
+            number_of_people_in_space = r.json()["number"]
+            list_of_people_in_space = r.json()["people"]
+        except:
+            print("API currently not available, using hardcoded data instead.")
+            number_of_people_in_space = 12
+            list_of_people_in_space = [
+                {"craft": "ISS", "name": "Oleg Kononenko"},
+                {"craft": "ISS", "name": "Nikolai Chub"},
+                {"craft": "ISS", "name": "Tracy Caldwell Dyson"},
+                {"craft": "ISS", "name": "Matthew Dominick"},
+                {"craft": "ISS", "name": "Michael Barratt"},
+                {"craft": "ISS", "name": "Jeanette Epps"},
+                {"craft": "ISS", "name": "Alexander Grebenkin"},
+                {"craft": "ISS", "name": "Butch Wilmore"},
+                {"craft": "ISS", "name": "Sunita Williams"},
+                {"craft": "Tiangong", "name": "Li Guangsu"},
+                {"craft": "Tiangong", "name": "Li Cong"},
+                {"craft": "Tiangong", "name": "Ye Guangfu"},
+            ]
+
+        context["ti"].xcom_push(
+            key="number_of_people_in_space", value=number_of_people_in_space
+        )
+        return list_of_people_in_space
+
+    @task
+    def print_astronaut_craft(greeting: str, person_in_space: dict) -> None:
+        """
+        This task creates a print statement with the name of an
+        Astronaut in space and the craft they are flying on from
+        the API request results of the previous task, along with a
+        greeting which is hard-coded in this example.
+        """
+        craft = person_in_space["craft"]
+        name = person_in_space["name"]
+
+        print(f"{name} is currently in space flying on the {craft}! {greeting}")
+
+    # Use dynamic task mapping to run the print_astronaut_craft task for each
+    # Astronaut in space
+    print_astronaut_craft.partial(greeting="Hello! :)").expand(
+        person_in_space=get_astronauts()  # Define dependencies using TaskFlow API syntax
+    )
+
+
+# Instantiate the DAG
+example_astronauts()

--- a/e2e-setup/astro-project/requirements.txt
+++ b/e2e-setup/astro-project/requirements.txt
@@ -1,0 +1,3 @@
+# Astro Runtime includes the following pre-installed providers packages: https://www.astronomer.io/docs/astro/runtime-image-architecture#provider-packages
+
+astro-run-dag # This package is needed for the astro run command. It will be removed before a deploy

--- a/e2e-setup/astro-project/tests/dags/test_dag_example.py
+++ b/e2e-setup/astro-project/tests/dags/test_dag_example.py
@@ -1,0 +1,83 @@
+"""Example DAGs test. This test ensures that all Dags have tags, retries set to two, and no import errors. This is an example pytest and may not be fit the context of your DAGs. Feel free to add and remove tests."""
+
+import os
+import logging
+from contextlib import contextmanager
+import pytest
+from airflow.models import DagBag
+
+
+@contextmanager
+def suppress_logging(namespace):
+    logger = logging.getLogger(namespace)
+    old_value = logger.disabled
+    logger.disabled = True
+    try:
+        yield
+    finally:
+        logger.disabled = old_value
+
+
+def get_import_errors():
+    """
+    Generate a tuple for import errors in the dag bag
+    """
+    with suppress_logging("airflow"):
+        dag_bag = DagBag(include_examples=False)
+
+        def strip_path_prefix(path):
+            return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
+
+        # prepend "(None,None)" to ensure that a test object is always created even if it's a no op.
+        return [(None, None)] + [
+            (strip_path_prefix(k), v.strip()) for k, v in dag_bag.import_errors.items()
+        ]
+
+
+def get_dags():
+    """
+    Generate a tuple of dag_id, <DAG objects> in the DagBag
+    """
+    with suppress_logging("airflow"):
+        dag_bag = DagBag(include_examples=False)
+
+    def strip_path_prefix(path):
+        return os.path.relpath(path, os.environ.get("AIRFLOW_HOME"))
+
+    return [(k, v, strip_path_prefix(v.fileloc)) for k, v in dag_bag.dags.items()]
+
+
+@pytest.mark.parametrize(
+    "rel_path,rv", get_import_errors(), ids=[x[0] for x in get_import_errors()]
+)
+def test_file_imports(rel_path, rv):
+    """Test for import errors on a file"""
+    if rel_path and rv:
+        raise Exception(f"{rel_path} failed to import with message \n {rv}")
+
+
+APPROVED_TAGS = {}
+
+
+@pytest.mark.parametrize(
+    "dag_id,dag,fileloc", get_dags(), ids=[x[2] for x in get_dags()]
+)
+def test_dag_tags(dag_id, dag, fileloc):
+    """
+    test if a DAG is tagged and if those TAGs are in the approved list
+    """
+    assert dag.tags, f"{dag_id} in {fileloc} has no tags"
+    if APPROVED_TAGS:
+        assert not set(dag.tags) - APPROVED_TAGS
+
+
+@pytest.mark.parametrize(
+    "dag_id,dag, fileloc", get_dags(), ids=[x[2] for x in get_dags()]
+)
+def test_dag_retries(dag_id, dag, fileloc):
+    """
+    test if a DAG has retries set
+    """
+    assert (
+        dag.default_args.get("retries", None) >= 2
+    ), f"{dag_id} in {fileloc} must have task retries >= 2."

--- a/e2e-setup/deployment-templates/deployment-hibernate.yaml
+++ b/e2e-setup/deployment-templates/deployment-hibernate.yaml
@@ -1,0 +1,34 @@
+deployment:
+  configuration:
+    name: deploy-action-hibernate-e2e
+    description: ""
+    runtime_version: 12.1.0
+    dag_deploy_enabled: true
+    ci_cd_enforcement: false
+    scheduler_size: SMALL
+    is_high_availability: false
+    is_development_mode: true
+    executor: CELERY
+    scheduler_count: 1
+    workspace_name: Deploy Action E2E
+    deployment_type: STANDARD
+    cloud_provider: AWS
+    region: us-east-1
+    default_task_pod_cpu: "0.25"
+    default_task_pod_memory: 0.5Gi
+    resource_quota_cpu: "10"
+    resource_quota_memory: 20Gi
+    workload_identity: ""
+  worker_queues:
+    - name: default
+      max_worker_count: 10
+      min_worker_count: 0
+      worker_concurrency: 5
+      worker_type: A5
+  hibernation_schedules:
+    - hibernate_at: 0 * * * *
+      wake_at: 1 * * * *
+      enabled: true
+    - hibernate_at: 1 * * * *
+      wake_at: 0 * * * *
+      enabled: true

--- a/e2e-setup/deployment-templates/deployment.yaml
+++ b/e2e-setup/deployment-templates/deployment.yaml
@@ -1,0 +1,27 @@
+deployment:
+  configuration:
+    name: deploy-action-non-dev-e2e
+    description: ""
+    runtime_version: 12.1.0
+    dag_deploy_enabled: true
+    ci_cd_enforcement: false
+    scheduler_size: SMALL
+    is_high_availability: false
+    is_development_mode: false
+    executor: CELERY
+    scheduler_count: 1
+    workspace_name: Deploy Action E2E
+    deployment_type: STANDARD
+    cloud_provider: AWS
+    region: us-east-1
+    default_task_pod_cpu: "0.25"
+    default_task_pod_memory: 0.5Gi
+    resource_quota_cpu: "10"
+    resource_quota_memory: 20Gi
+    workload_identity: ""
+  worker_queues:
+    - name: default
+      max_worker_count: 10
+      min_worker_count: 0
+      worker_concurrency: 5
+      worker_type: A5

--- a/e2e-setup/mocks/git.sh
+++ b/e2e-setup/mocks/git.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # hack to mock git commands as part of action.yaml so that we could simulate dags only deploy scenario without making any additional commits
-echo "e2e/astro-project/dags/exampledag.py"
+echo "e2e-setup/astro-project/dags/exampledag.py"

--- a/e2e-setup/mocks/git.sh
+++ b/e2e-setup/mocks/git.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 
 # hack to mock git commands as part of action.yaml so that we could simulate dags only deploy scenario without making any additional commits
-echo "e2e-setup/astro-project/dags/exampledag.py"
+
+# Check if the script was invoked with "git diff"
+if [[ "$1" == "diff" ]]; then
+  echo "e2e-setup/astro-project/dags/exampledag.py"
+elif [[ "$1" == "fetch" ]]; then
+  echo "Handling git fetch, doing nothing"
+else
+  echo "Error: git mock script isn't configured to handle $1" >&2
+  exit 1
+fi

--- a/e2e-setup/mocks/git.sh
+++ b/e2e-setup/mocks/git.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# hack to mock git commands as part of action.yaml so that we could simulate dags only deploy scenario without making any additional commits
+echo "e2e/astro-project/dags/exampledag.py"


### PR DESCRIPTION
Changes:

- Add an e2e tests framework to add different test scenarios for deploy actions. This framework has some minor limitations considering this is not a very actively developed project: 
  - To not increase the cost dramatically, these tests are only run on demand or when a new commit is pushed against the main. So that while developing we don't trigger unnecessary runs by each commit push to our development branch. We could update the branch protection rule to include a status check for the e2e tests as a requirement to merge the PR, so that PR is only merged when e2e tests are passing, but e2e tests are still not executed on every commit
- Adds test scenarios for existing logic to run against a hibernating and a non-hibernating deployment, this includes:
  - Test for DAG Deploy for default deployment
  - Test for custom image push for default deployment
  - Test for pytest and image push for default deployment
  - Deployment preview creation
  - Test for DAG Deploy for deployment preview
  - Test for image push for deployment preview
  - Deployment preview deletion

<img width="1861" alt="image" src="https://github.com/user-attachments/assets/e19552f3-bb77-4f04-8ad6-f1843c52b709">


Closes: astronomer/astro#23802