### PR TITLE
revert deployment hibernate changes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,10 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deployment: [deployment-hibernate.yaml, deployment.yaml]
+        deployment: [deployment.yaml]
     outputs:
       DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.DEPLOYMENT_ID }}
-      HIBERNATE_DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.HIBERNATE_DEPLOYMENT_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,11 +98,7 @@ jobs:
           sed -i "s|  name:.*|  name: deploy-action-e2e-${{ env.test_uid }}|g"  e2e-setup/deployment-templates/${{ matrix.deployment }}
 
           DEPLOYMENT_ID=$(astro deployment create --deployment-file e2e-setup/deployment-templates/${{ matrix.deployment }} | yq e '.deployment.metadata.deployment_id' -)
-          if [[ "${{ matrix.deployment }}" == "deployment.yaml" ]]; then
-            echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
-          else
-            echo "HIBERNATE_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
-          fi
+          echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
   # DAG Deploy test would test the DAG only deploy functionality in deploy action
   dag-deploy-test:
@@ -113,10 +108,7 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -191,10 +183,7 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -274,10 +263,7 @@ jobs:
       max-parallel: 1
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
         deploy_type: [dags, image-and-dags]
     steps:
       - name: Checkout code
@@ -357,14 +343,11 @@ jobs:
   no-deploy-test:
     name: No Deploy Test
     runs-on: ubuntu-latest
-    needs: [infer-image-deploy, create-test-deployments]
+    needs: [infer-deploy, create-test-deployments]
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
         deploy_type: [infer, dbt, dags, image-and-dags]
     steps:
       - name: Checkout code
@@ -464,10 +447,7 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -543,10 +523,7 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -629,10 +606,7 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          [
-            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
-            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
-          ]
+          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -893,4 +867,3 @@ jobs:
       - name: Delete Deployment
         run: |
           astro deployment delete -f ${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}
-          astro deployment delete -f ${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}

--- a/action.yaml
+++ b/action.yaml
@@ -433,39 +433,6 @@ runs:
         echo ::endgroup::
       shell: bash
       id: deploy-options
-    - name: Determine if Development Mode is enabled
-      run: |
-
-        echo ::group::Determine if Development Mode is enabled
-        if [[ ${{ inputs.action }} != delete-deployment-preview ]]; then
-          DEPLOYMENT_TYPE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.deployment_type)
-          # only inspect development mode if deployment is not hybrid
-          if [[ $DEPLOYMENT_TYPE != "HYBRID" ]]; then
-            DEV_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)
-            echo "Deployment development mode: $DEV_MODE"
-            if [[ $DEV_MODE == "" ]]; then
-              echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
-            else
-              echo "DEVELOPMENT_MODE=$DEV_MODE" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
-        fi
-        echo ::endgroup::
-      shell: bash
-      id: development-mode
-    - name: Override to wake up the Deployment
-      if: ${{ inputs.action != 'delete-deployment-preview' && steps.development-mode.outputs.DEVELOPMENT_MODE == 'true' }}
-      run: |
-        echo ::group::Override to wake up the Deployment
-        astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
-        # Give it some time to wake up
-        sleep 60
-        echo ::endgroup::
-      shell: bash
     - name: DAG Deploy to Astro
       if: ${{ (inputs.deploy-type == 'dags-only' || inputs.deploy-type == 'infer') && steps.deploy-type.outputs.DAGS_ONLY_DEPLOY == 'true' }}
       run: |
@@ -509,13 +476,5 @@ runs:
         if [[ ${{ inputs.copy-pools }} == true ]]; then
           astro deployment pool copy --source-id ${{steps.deployment-preview.outputs.ORIGINAL_DEPLOYMENT_ID}} --target-id ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}}
         fi
-        echo ::endgroup::
-      shell: bash
-    - name: Remove override on Deployment to resume schedule
-      if: ${{ steps.development-mode.outputs.DEVELOPMENT_MODE == 'true' }}
-      run: |
-
-        echo ::group::Remove override on Deployment to resume schedule
-        astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --remove-override --force
         echo ::endgroup::
       shell: bash


### PR DESCRIPTION
## Description:

Reverting changes related to hibernate deployment wake up before deploy because we realized that the change does not respect the existing override configured on the deployment, which means that if a deployment has an override configured, the deploy action would delete that override and won't re-configure it at the end.

It's not a straightforward fix, because CLI does not output the hibernation override information correctly (i.e. sends a pointer instead of a boolean value in the inspect command output), so the plan is to fix revert the change as now to unblock dbt deploy release and fix it cleanly in the next release.