### PR TITLE
Add option to wake dev deployments on deploy

### DIFF
--- a/.github/workflows/e2e/get_deployment_info/action.yaml
+++ b/.github/workflows/e2e/get_deployment_info/action.yaml
@@ -24,6 +24,9 @@ outputs:
   desired_image_version:
     description: The image version
     value: ${{ steps.get-deployment-info.outputs.desired_image_version }}
+  hibernation_spec:
+    description: The hibernation spec
+    value: ${{ steps.get-deployment-info.outputs.hibernation_spec }}
 
 runs:
   using: "composite"
@@ -39,5 +42,7 @@ runs:
         fi
         desired_dag_tarball_version=$(cat response.json | jq -r '.desiredDagTarballVersion')
         desired_image_version=$(cat response.json | jq -r '.desiredImageVersion')
+        hibernation_spec=$(cat response.json | jq -r '.scalingSpec.hibernationSpec')
         echo "desired_dag_tarball_version=$desired_dag_tarball_version" >> $GITHUB_OUTPUT
         echo "desired_image_version=$desired_image_version" >> $GITHUB_OUTPUT
+        echo "hibernation_spec=$hibernation_spec" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e/get_deployment_info/action.yaml
+++ b/.github/workflows/e2e/get_deployment_info/action.yaml
@@ -42,7 +42,7 @@ runs:
         fi
         desired_dag_tarball_version=$(cat response.json | jq -r '.desiredDagTarballVersion')
         desired_image_version=$(cat response.json | jq -r '.desiredImageVersion')
-        hibernation_spec=$(cat response.json | jq -r '.scalingSpec.hibernationSpec')
+        hibernation_spec=$(cat response.json | jq -rc '.scalingSpec.hibernationSpec')
         echo "desired_dag_tarball_version=$desired_dag_tarball_version" >> $GITHUB_OUTPUT
         echo "desired_image_version=$desired_image_version" >> $GITHUB_OUTPUT
         echo "hibernation_spec=$hibernation_spec" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e/validate_deployment/action.yaml
+++ b/.github/workflows/e2e/validate_deployment/action.yaml
@@ -8,6 +8,9 @@ inputs:
   is_no_deploy:
     description: If the deploy test was a no-op
     default: false
+  is_wake_on_deploy:
+    description: If the deploy test was a wake-on-deploy
+    default: false
   dag_tarball_version_before:
     description: The desired DAG tarball version before the test
     required: true
@@ -19,6 +22,12 @@ inputs:
     required: true
   image_version_after:
     description: The image version after the test
+    required: true
+  hibernation_spec_before:
+    description: The hibernation spec before the test
+    required: true
+  hibernation_spec_after:
+    description: The hibernation spec after the test
     required: true
 
 runs:
@@ -55,3 +64,17 @@ runs:
         fi
         echo "Deploy Action validation failed: neither desiredDagTarballVersion or imageVersion were updated after the test"
         exit 1
+
+    - name: Validate Hibernation Spec
+      id: validate-hibernation-spec
+      shell: bash
+      run: |
+
+        if [[ "${{ inputs.is_wake_on_deploy }}" == "true" ]]; then
+          if [[ "${{ inputs.hibernation_spec_before }}" == "${{ inputs.hibernation_spec_after }}" ]]; then
+            echo "Hibernation Spec validation succeeded: hibernation spec was not updated after the test"
+            exit 0
+          fi
+          echo "Hibernation Spec validation failed: hibernation spec updated"
+          exit 1
+        fi

--- a/.github/workflows/e2e/validate_deployment/action.yaml
+++ b/.github/workflows/e2e/validate_deployment/action.yaml
@@ -71,7 +71,7 @@ runs:
       run: |
 
         if [[ "${{ inputs.is_wake_on_deploy }}" == "true" ]]; then
-          if [[ "${{ inputs.hibernation_spec_before }}" == "${{ inputs.hibernation_spec_after }}" ]]; then
+          if [[ '${{ inputs.hibernation_spec_before }}' == '${{ inputs.hibernation_spec_after }}' ]]; then
             echo "Hibernation Spec validation succeeded: hibernation spec was not updated after the test"
             exit 0
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,9 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deployment: [deployment.yaml]
+        deployment: [deployment-hibernate.yaml, deployment.yaml]
     outputs:
       DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.DEPLOYMENT_ID }}
+      HIBERNATE_DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.HIBERNATE_DEPLOYMENT_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -98,8 +99,11 @@ jobs:
           sed -i "s|  name:.*|  name: deploy-action-e2e-${{ env.test_uid }}|g"  e2e-setup/deployment-templates/${{ matrix.deployment }}
 
           DEPLOYMENT_ID=$(astro deployment create --deployment-file e2e-setup/deployment-templates/${{ matrix.deployment }} | yq e '.deployment.metadata.deployment_id' -)
-          echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
-
+          if [[ "${{ matrix.deployment }}" == "deployment.yaml" ]]; then
+            echo "DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+          else
+            echo "HIBERNATE_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+          fi
   default-deploy-tests:
     name: Default Deploy Test
     runs-on: ubuntu-latest
@@ -108,7 +112,10 @@ jobs:
       max-parallel: 1
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
         deploy_type: [dags, image-and-dags]
     steps:
       - name: Checkout code
@@ -166,6 +173,7 @@ jobs:
         with:
           deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -193,7 +201,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -242,6 +253,7 @@ jobs:
           workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           parse: true
           root-folder: e2e-setup/astro-project
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -268,7 +280,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -322,6 +337,7 @@ jobs:
           action: deploy
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -348,7 +364,10 @@ jobs:
       max-parallel: 1
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
         deploy_type: [dags, image-and-dags]
     steps:
       - name: Checkout code
@@ -406,6 +425,7 @@ jobs:
           parse: true
           action: deploy
           root-folder: e2e-setup/astro-project
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -432,7 +452,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
         deploy_type: [infer, dbt, dags, image-and-dags]
     steps:
       - name: Checkout code
@@ -487,6 +510,7 @@ jobs:
           action: deploy
           deploy-type: ${{ matrix.deploy_type }}
           root-folder: ${{ matrix.deploy_type == 'dbt' && 'e2e-setup/dbt' || 'e2e-setup/astro-project' }}
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -539,7 +563,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -589,6 +616,7 @@ jobs:
           action: deploy
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -615,7 +643,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -661,6 +692,7 @@ jobs:
           root-folder: e2e-setup/dbt
           deploy-type: dbt
           description: "test-dbt-deploy-action"
+          wake-on-deploy: true
 
       - name: Get DBT bundle info
         id: get-dbt-bundle-info
@@ -698,7 +730,10 @@ jobs:
     strategy:
       matrix:
         deployment_id:
-          ["${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}"]
+          [
+            "${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}",
+            "${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}",
+          ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -744,6 +779,7 @@ jobs:
           copy-connections: false
           copy-airflow-variables: false
           copy-pools: false
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-create-preview
@@ -787,6 +823,7 @@ jobs:
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
           preview-name: test-preview-${{ matrix.deployment_id }}
+          wake-on-deploy: true
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-deploy-preview
@@ -831,6 +868,7 @@ jobs:
           deploy-type: dags-only
           root-folder: e2e-setup/astro-project
           preview-name: test-preview-${{ matrix.deployment_id }}
+          wake-on-deploy: true
 
       - name: Get Deployment Info After DAG Deploy Test
         id: get-deployment-after-dag-deploy
@@ -867,6 +905,7 @@ jobs:
           description: "test-dbt-deploy-action"
           root-folder: e2e-setup/dbt
           preview-name: test-preview-${{ matrix.deployment_id }}
+          wake-on-deploy: true
 
       - name: Get DBT bundle info
         id: get-dbt-bundle-info
@@ -959,3 +998,4 @@ jobs:
       - name: Delete Deployment
         run: |
           astro deployment delete -f ${{ needs.create-test-deployments.outputs.DEPLOYMENT_ID }}
+          astro deployment delete -f ${{ needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -173,7 +173,7 @@ jobs:
         with:
           deployment-id: ${{ matrix.deployment_id }}
           workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -187,11 +187,14 @@ jobs:
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           is_dag_only_deploy: ${{ matrix.deploy_type == 'dags' }}
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
   # DAG Deploy test would test the DAG only deploy functionality in deploy action
   dag-deploy-test:
@@ -253,7 +256,7 @@ jobs:
           workspace: ${{ steps.get-astro-env-info.outputs.workspace_id }}
           parse: true
           root-folder: e2e-setup/astro-project
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -267,11 +270,14 @@ jobs:
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           is_dag_only_deploy: true
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
   pytests-test:
     name: Pytest Test
@@ -337,7 +343,7 @@ jobs:
           action: deploy
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -351,10 +357,13 @@ jobs:
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
   infer-deploy:
     name: Infer Deploy Test
@@ -425,7 +434,7 @@ jobs:
           parse: true
           action: deploy
           root-folder: e2e-setup/astro-project
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -439,11 +448,14 @@ jobs:
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           is_dag_only_deploy: ${{ matrix.deploy_type == 'dags' }}
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
   no-deploy-test:
     name: No Deploy Test
@@ -510,7 +522,7 @@ jobs:
           action: deploy
           deploy-type: ${{ matrix.deploy_type }}
           root-folder: ${{ matrix.deploy_type == 'dbt' && 'e2e-setup/dbt' || 'e2e-setup/astro-project' }}
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -526,11 +538,14 @@ jobs:
         if: ${{ matrix.deploy_type != 'dbt' }}
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           is_no_deploy: true
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
       - name: Get DBT bundle info
         id: get-dbt-bundle-info
@@ -616,7 +631,7 @@ jobs:
           action: deploy
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after
@@ -630,10 +645,13 @@ jobs:
       - name: Validate Deploy Action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ${{ steps.get-deployment-before.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after.outputs.desiredDagTarballVersion }}
           image_version_after: ${{ steps.get-deployment-after.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after.outputs.hibernation_spec }}
 
   # DBT Deploy test would test the DAG only deploy functionality in deploy action
   dbt-deploy-test:
@@ -692,7 +710,7 @@ jobs:
           root-folder: e2e-setup/dbt
           deploy-type: dbt
           description: "test-dbt-deploy-action"
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get DBT bundle info
         id: get-dbt-bundle-info
@@ -779,7 +797,7 @@ jobs:
           copy-connections: false
           copy-airflow-variables: false
           copy-pools: false
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-create-preview
@@ -794,10 +812,13 @@ jobs:
         id: validate-deployment-preview-create
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ""
           image_version_before: "12.2.0"
+          hibernation_spec_before: '{"schedules":[{"isEnabled":true,"hibernateAtCron":"0 * * * *","wakeAtCron":"1 * * * *"},{"isEnabled":true,"hibernateAtCron":"1 * * * *","wakeAtCron":"0 * * * *"}]}'
           dag_tarball_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after-create-preview.outputs.hibernation_spec }}
 
       - name: Mock git commands
         run: |
@@ -823,7 +844,7 @@ jobs:
           deploy-type: image-and-dags
           root-folder: e2e-setup/astro-project
           preview-name: test-preview-${{ matrix.deployment_id }}
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After Test
         id: get-deployment-after-deploy-preview
@@ -838,10 +859,13 @@ jobs:
         id: validate-deployment-preview-deploy
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ${{ steps.get-deployment-before-deploy.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before-deploy.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before-deploy.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after-deploy-preview.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-deploy-preview.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after-deploy-preview.outputs.hibernation_spec }}
 
       - name: Mock git commands for DAG Deploy
         run: |
@@ -868,7 +892,7 @@ jobs:
           deploy-type: dags-only
           root-folder: e2e-setup/astro-project
           preview-name: test-preview-${{ matrix.deployment_id }}
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get Deployment Info After DAG Deploy Test
         id: get-deployment-after-dag-deploy
@@ -883,11 +907,14 @@ jobs:
         id: validate-dag-deploy-action
         uses: ./.github/workflows/e2e/validate_deployment
         with:
+          is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           is_dag_only_deploy: true
           dag_tarball_version_before: ${{ steps.get-deployment-before-dag-deploy.outputs.desired_dag_tarball_version }}
           image_version_before: ${{ steps.get-deployment-before-dag-deploy.outputs.desired_image_version }}
+          hibernation_spec_before: ${{ steps.get-deployment-before-dag-deploy.outputs.hibernation_spec }}
           dag_tarball_version_after: ${{ steps.get-deployment-after-dag-deploy.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-dag-deploy.outputs.desired_image_version }}
+          hibernation_spec_after: ${{ steps.get-deployment-after-dag-deploy.outputs.hibernation_spec }}
 
       - name: Mock git commands for DBT Deploy
         run: |
@@ -905,7 +932,7 @@ jobs:
           description: "test-dbt-deploy-action"
           root-folder: e2e-setup/dbt
           preview-name: test-preview-${{ matrix.deployment_id }}
-          wake-on-deploy: true
+          wake-on-deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
 
       - name: Get DBT bundle info
         id: get-dbt-bundle-info

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |
 | `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
+| `wake-on-deploy` | `false` | If true, the deployment will be woken up from hibernation before deploying. NOTE: This option overrides the deployment's hibernation override spec. |
 
 
 ## Outputs
@@ -246,6 +247,21 @@ steps:
     root-folder: astro-project/
     parse: true
 ```
+
+### Wake on deploy
+
+In the following example, the deployment is woken up from hibernation before deploying via the `wake-on-deploy` option.
+
+```yaml
+steps:
+- name: Deploy to Astro
+  uses: astronomer/deploy-action@v0.7.1
+  with:
+    deployment-id: <deployment id>
+    wake-on-deploy: true
+```
+
+This is especially useful when you have a deployment that is hibernated and you want to deploy to it. This option overrides the deployment's hibernation override spec.
 
 ## Deployment Preview Templates
 

--- a/action.yaml
+++ b/action.yaml
@@ -94,6 +94,10 @@ inputs:
     required: false
     default: false
     description: "Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`."
+  wake-on-deploy:
+    required: false
+    default: false
+    description: "If true, the deployment will be woken up from hibernation before deploying. NOTE: This option overrides the deployment's hibernation override spec."
 outputs:
   preview-id:
     description: "The ID of the created deployment preview. Only works when action=create-deployment-preview"
@@ -449,6 +453,35 @@ runs:
         echo ::endgroup::
       shell: bash
       id: deploy-options
+    - name: Determine if Development Mode is enabled
+      if: ${{ inputs.wake-on-deploy == 'true' && inputs.action != 'delete-deployment-preview' }}
+      run: |
+        echo ::group::Determine if Development Mode is enabled
+        DEPLOYMENT_TYPE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.deployment_type)
+        # only inspect development mode if deployment is not hybrid
+        if [[ $DEPLOYMENT_TYPE != "HYBRID" ]]; then
+          DEV_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)
+          echo "Deployment development mode: $DEV_MODE"
+          if [[ $DEV_MODE == "" ]]; then
+            echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
+          else
+            echo "DEVELOPMENT_MODE=$DEV_MODE" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "DEVELOPMENT_MODE=false" >> $GITHUB_OUTPUT
+        fi
+        echo ::endgroup::
+      shell: bash
+      id: development-mode
+    - name: Override to wake up the Deployment
+      if: ${{ inputs.wake-on-deploy == 'true' && inputs.action != 'delete-deployment-preview' && steps.development-mode.outputs.DEVELOPMENT_MODE == 'true' }}
+      run: |
+        echo ::group::Override to wake up the Deployment
+        astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
+        # Give it some time to wake up
+        sleep 60
+        echo ::endgroup::
+      shell: bash
     - name: DAG Deploy to Astro
       if: ${{ (inputs.deploy-type == 'dags-only' || inputs.deploy-type == 'infer') && steps.deploy-type.outputs.DAGS_ONLY_DEPLOY == 'true' }}
       run: |
@@ -504,5 +537,12 @@ runs:
         if [[ ${{ inputs.copy-pools }} == true ]]; then
           astro deployment pool copy --source-id ${{steps.deployment-preview.outputs.ORIGINAL_DEPLOYMENT_ID}} --target-id ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}}
         fi
+        echo ::endgroup::
+      shell: bash
+    - name: Remove override on Deployment to resume schedule
+      if: ${{ inputs.wake-on-deploy == 'true' && inputs.action != 'delete-deployment-preview' && steps.development-mode.outputs.DEVELOPMENT_MODE == 'true' }}
+      run: |
+        echo ::group::Remove override on Deployment to resume schedule
+        astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --remove-override --force
         echo ::endgroup::
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -478,8 +478,11 @@ runs:
       run: |
         echo ::group::Override to wake up the Deployment
         astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
-        # Give it some time to wake up
-        sleep 60
+        # Wait for the deployment to wake up
+        while [ "$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key metadata.status)" == "HIBERNATING" ]
+        do
+          sleep 5
+        done
         echo ::endgroup::
       shell: bash
     - name: DAG Deploy to Astro


### PR DESCRIPTION
## Description

This adds a new `wake-on-deploy` input that creates a hibernation override to ensure the dev deployment is awake before deploying and resumes hibernation schedules afterward.

> [!NOTE]  
> This means it will override whatever existing hibernation override is on the deployment when `wake-on-deploy` is used.

## Motivation

fixes: https://github.com/astronomer/deploy-action/issues/81

## Testing

- [x] [E2E Test](https://github.com/astronomer/deploy-action/actions/runs/11550456124)