### PR TITLE
Handle case when triggered event is a new branch or a tag push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/tag-event-case
   workflow_dispatch:
     inputs:
       workspace_id:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/tag-event-case
   workflow_dispatch:
     inputs:
       workspace_id:

--- a/action.yaml
+++ b/action.yaml
@@ -311,7 +311,7 @@ runs:
 
         DBT_DEPLOY=false
 
-        # case when the triggered event is a new tag creation, then we would need to deploy the dbt project to be on the safe side
+        # case when the triggered event is a new branch or tag creation, we would need to deploy the dbt project because we cannot determine that it does not need to be deployed
         if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
         then
           DBT_DEPLOY=true
@@ -364,7 +364,7 @@ runs:
         DAGS_ONLY_DEPLOY=false
         SKIP_IMAGE_OR_DAGS_DEPLOY=true
 
-        # case when the triggered event is a new tag creation, then we would need to deploy the image to be on the safe side
+        # case when the triggered event is a new branch or tag creation, we would need to deploy the image because we cannot determine that it does not need to be deployed
         if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
         then
           DAGS_ONLY_DEPLOY=false

--- a/action.yaml
+++ b/action.yaml
@@ -311,7 +311,7 @@ runs:
 
         DBT_DEPLOY=false
 
-        # case when the triggered event is a new branch or tag creation, then we would need to deploy the dbt project to be on the safe side
+        # case when the triggered event is a new tag creation, then we would need to deploy the dbt project to be on the safe side
         if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
         then
           DBT_DEPLOY=true
@@ -364,7 +364,7 @@ runs:
         DAGS_ONLY_DEPLOY=false
         SKIP_IMAGE_OR_DAGS_DEPLOY=true
 
-        # case when the triggered event is a new branch or tag creation, then we would need to deploy the image to be on the safe side
+        # case when the triggered event is a new tag creation, then we would need to deploy the image to be on the safe side
         if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
         then
           DAGS_ONLY_DEPLOY=false

--- a/action.yaml
+++ b/action.yaml
@@ -308,9 +308,18 @@ runs:
         branch=$(echo "${GITHUB_REF#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
-        files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
-        echo "Files changed: $files"
+
         DBT_DEPLOY=false
+
+        # case when the triggered event is a new branch or tag creation, then we would need to deploy the dbt project to be on the safe side
+        if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
+        then
+          DBT_DEPLOY=true
+          files=()
+        else
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          echo "files changed: $files"
+        fi
 
         for file in $files; do
           if [[ $file =~ ^"${{ inputs.root-folder }}".* ]]; then
@@ -351,11 +360,20 @@ runs:
         branch=$(echo "${GITHUB_REF#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
-        files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
-        echo "files changed: $files"
 
         DAGS_ONLY_DEPLOY=false
         SKIP_IMAGE_OR_DAGS_DEPLOY=true
+
+        # case when the triggered event is a new branch or tag creation, then we would need to deploy the image to be on the safe side
+        if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]
+        then
+          DAGS_ONLY_DEPLOY=false
+          SKIP_IMAGE_OR_DAGS_DEPLOY=false
+          files=()
+        else
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          echo "files changed: $files"
+        fi
 
         for file in $files; do
           if [[ $file =~ ^"${{ inputs.root-folder }}".* ]]; then


### PR DESCRIPTION
### Description:

Fix the case when the before SHA for the triggered event is null (i.e. case when a new tag is pushed), in which case now we would do an image deploy and a dbt deploy (if configured), to be on the safe side.

### Testing:

manually running the tests, since it is not straightforward to replicate the behavior in e2e tests. The below screenshot shows a run in a repo that had an "on tag" trigger event.
<img width="1862" alt="Screenshot 2024-10-28 at 2 32 18 PM" src="https://github.com/user-attachments/assets/c198ab35-7456-4aa1-b0a7-0e6458969be9">
Reference: https://github.com/neel-astro/example-repo-update/actions/runs/11550491614/job/32145579388


Fixes: https://github.com/astronomer/deploy-action/issues/82