### PR TITLE
Update runtime versions and aws region for test deployments

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -814,7 +814,7 @@ jobs:
         with:
           is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ""
-          image_version_before: "12.2.0"
+          image_version_before: "12.5.0"
           hibernation_spec_before: '{"schedules":[{"isEnabled":true,"hibernateAtCron":"0 * * * *","wakeAtCron":"1 * * * *"},{"isEnabled":true,"hibernateAtCron":"1 * * * *","wakeAtCron":"0 * * * *"}]}'
           dag_tarball_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_image_version }}

--- a/e2e-setup/astro-project/Dockerfile
+++ b/e2e-setup/astro-project/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:12.2.0
+FROM quay.io/astronomer/astro-runtime:12.5.0

--- a/e2e-setup/deployment-templates/deployment-hibernate.yaml
+++ b/e2e-setup/deployment-templates/deployment-hibernate.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-hibernate-e2e
     description: ""
-    runtime_version: 12.2.0
+    runtime_version: 12.5.0
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL
@@ -13,7 +13,7 @@ deployment:
     workspace_name: Deploy Action E2E
     deployment_type: STANDARD
     cloud_provider: AWS
-    region: us-east-1
+    region: us-west-2
     default_task_pod_cpu: "0.25"
     default_task_pod_memory: 0.5Gi
     resource_quota_cpu: "10"

--- a/e2e-setup/deployment-templates/deployment.yaml
+++ b/e2e-setup/deployment-templates/deployment.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-non-dev-e2e
     description: ""
-    runtime_version: 12.2.0
+    runtime_version: 12.5.0
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL
@@ -13,7 +13,7 @@ deployment:
     workspace_name: Deploy Action E2E
     deployment_type: STANDARD
     cloud_provider: AWS
-    region: us-east-1
+    region: us-west-2
     default_task_pod_cpu: "0.25"
     default_task_pod_memory: 0.5Gi
     resource_quota_cpu: "10"


### PR DESCRIPTION
Changes:
- Updated runtime version to `12.5.0`
- Updated deployment region to `us-west-2`, since `us-east-1` is unavailable at the moment