### PR TITLE
feat: add branch input

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `workspace` | | Workspace id to select. Only required when `ASTRO_API_TOKEN` is given an organization token. |
 | `preview-name` | `false` | Specifies custom preview name. By default this is branch name “_” deployment name. |
 | `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action. Your custom checkout step needs to have `fetch-depth` of `0` and `ref` equal to `${{ github.event.after }}` so all the commits in the PR are checked out. Look at the checkout step that runs within this action for reference. |
+| `branch` | `` | Branch to deploy from. Default is the branch the action is running on. |
 | `deploy-image` | `false` | If true image and DAGs will deploy for any action that deploys code. NOTE: This option is deprecated and will be removed in a future release. Use `deploy-type: image-and-dags` instead. |
 | `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |

--- a/action.yaml
+++ b/action.yaml
@@ -65,6 +65,10 @@ inputs:
     required: false
     default: true
     description: "Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action"
+  branch:
+    required: false
+    default: ""
+    description: "The branch to checkout. If not specified, the branch will be inferred from the event."
   description:
     required: false
     description: >
@@ -301,6 +305,8 @@ runs:
       id: dag-deploy-enabled
     - name: Get DBT Deploy Options
       if: ${{ inputs.deploy-type == 'dbt' }}
+      env:
+        BRANCH: ${{ inputs.branch || github.ref }}
       run: |
 
         echo ::group::Get DBT Deploy Options
@@ -309,7 +315,7 @@ runs:
           cd ${{ inputs.root-folder }}
         fi
 
-        branch=$(echo "${GITHUB_REF#refs/heads/}")
+        branch=$(echo "${BRANCH#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
 
@@ -353,6 +359,8 @@ runs:
       id: dbt-deploy-options
     - name: Get Deploy Type
       if: ${{ inputs.deploy-type == 'infer' || inputs.deploy-type == 'dags-only' || inputs.deploy-type == 'image-and-dags' }}
+      env:
+        BRANCH: ${{ inputs.branch || github.ref }}
       run: |
 
         # infer based on files changed to deploy only dags or image and dags
@@ -362,7 +370,7 @@ runs:
           cd ${{ inputs.root-folder }}
         fi
 
-        branch=$(echo "${GITHUB_REF#refs/heads/}")
+        branch=$(echo "${BRANCH#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
 


### PR DESCRIPTION
This pull request adds functionality to specify a branch to deploy from in the `Deploy to Astro` action. The most important changes include updates to the `README.md` and `action.yaml` files to document and implement the new `branch` input option.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R65): Added description for the new `branch` input option in the configuration options table.

Implementation updates:

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR68-R71): Added the `branch` input option with a default value and description.
* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR308-R309): Updated the `runs` section to use the `branch` input or default to the current GitHub reference.