### PR TITLE
Fix issue #102 "Handled Delete preview deployment bug when branch name contain '/' in it"

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -242,19 +242,14 @@ runs:
 
           if [[ "${{ inputs.preview-name }}" != "" ]]; then
             BRANCH_DEPLOYMENT_NAME="${{ inputs.preview-name }}"
-          else
-            # Get deployment name from Astro if preview-name is not provided
-            DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
-           # Check if the branch name is available in GITHUB_HEAD_REF
-           if [[ ${GITHUB_HEAD_REF##*/} != "" ]]; then
-              BRANCH_DEPLOYMENT_NAME=${GITHUB_HEAD_REF##*/}_$DEPLOYMENT_NAME
-           else
-           # Fallback to using github.ref if GITHUB_HEAD_REF is not set
-              branch_ref="${{ github.ref }}"
+            else
+              # Get deployment name from Astro if preview-name is not provided
+              DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
+              # using github.event.ref 
+              branch_ref="${{ github.event.ref }}"
               branch_name="${branch_ref##*/}"
               BRANCH_DEPLOYMENT_NAME=${branch_name}_$DEPLOYMENT_NAME
-           fi
-            BRANCH_DEPLOYMENT_NAME="${BRANCH_DEPLOYMENT_NAME// /_}"
+              BRANCH_DEPLOYMENT_NAME="${BRANCH_DEPLOYMENT_NAME// /_}"
           fi
           # delete branch deployment
           astro deployment delete -n $BRANCH_DEPLOYMENT_NAME -f

--- a/action.yaml
+++ b/action.yaml
@@ -242,10 +242,18 @@ runs:
 
           if [[ "${{ inputs.preview-name }}" != "" ]]; then
             BRANCH_DEPLOYMENT_NAME="${{ inputs.preview-name }}"
-
           else
+            # Get deployment name from Astro if preview-name is not provided
             DEPLOYMENT_NAME="$(astro deployment inspect $DEPLOYMENT_ID --clean-output --key configuration.name)"
-            BRANCH_DEPLOYMENT_NAME=${{ github.event.ref }}_$DEPLOYMENT_NAME
+           # Check if the branch name is available in GITHUB_HEAD_REF
+           if [[ ${GITHUB_HEAD_REF##*/} != "" ]]; then
+              BRANCH_DEPLOYMENT_NAME=${GITHUB_HEAD_REF##*/}_$DEPLOYMENT_NAME
+           else
+           # Fallback to using github.ref if GITHUB_HEAD_REF is not set
+              branch_ref="${{ github.ref }}"
+              branch_name="${branch_ref##*/}"
+              BRANCH_DEPLOYMENT_NAME=${branch_name}_$DEPLOYMENT_NAME
+           fi
             BRANCH_DEPLOYMENT_NAME="${BRANCH_DEPLOYMENT_NAME// /_}"
           fi
           # delete branch deployment


### PR DESCRIPTION
Code Changes:

Implemented the same filtering logic used during preview deployment creation to ensure consistency of deployment name.
Extracted the branch name from the GitHub event reference and applied the logic below to form the deployment name. 

```
branch_ref="${{ github.event.ref }}"
branch_name="${branch_ref##*/}"
BRANCH_DEPLOYMENT_NAME=${branch_name}_$DEPLOYMENT_NAME
```


