### PR TITLE
Dag only deploy option should not do secondary check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -394,10 +394,7 @@ runs:
                 break
               fi
             elif [[ ${{ inputs.deploy-type }} == 'dags-only' ]]; then
-              if [[ $file == *"dags/"* ]]; then
-                echo $file is part of dags folder
-                DAGS_ONLY_DEPLOY=true
-              fi
+              DAGS_ONLY_DEPLOY=true
             elif [[ ${{ inputs.deploy-type }} == 'image-and-dags' ]]; then
               DAGS_ONLY_DEPLOY=false
               break


### PR DESCRIPTION
If a user is doing secondary manipulation of a filesystem to create a dags/ folder from multiple sources, the check on dags/ being changed in the diff will fail even though only dags have changed. This makes sense for infer, but we need to have an option where the user's indication that this is a dag-only deploy is trusted.