### PR TITLE
Handle case for branch rebase/force push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,9 +79,7 @@ jobs:
       - name: Install dependencies
         run: |
 
-          sudo add-apt-repository ppa:rmescandon/yq
-          sudo apt update
-          sudo apt install yq -y
+          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
 
           curl -sSL https://install.astronomer.io | sudo bash -s
           astro context switch ${{ steps.get-astro-env-info.outputs.astronomer_host }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,27 +2,6 @@ name: E2E Tests for Astro Deploy Action
 
 on:
   push:
-    branches:
-      - main
-      - fix/rebase-force-push
-  workflow_dispatch:
-    inputs:
-      workspace_id:
-        description: "Workspace ID"
-        required: false
-        default: ""
-      org_id:
-        description: "Organization ID"
-        required: false
-        default: ""
-      astronomer_host:
-        description: "Astronomer Host"
-        required: false
-        default: ""
-      token:
-        description: "API Token"
-        required: false
-        default: ""
 
 env:
   ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
@@ -31,6 +10,7 @@ jobs:
   redact-inputs:
     name: Redact Inputs
     runs-on: ubuntu-latest
+    environment: e2e-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -793,7 +793,7 @@ jobs:
         with:
           is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ""
-          image_version_before: "12.6.0"
+          image_version_before: "12.7.1"
           hibernation_spec_before: '{"schedules":[{"isEnabled":true,"hibernateAtCron":"0 * * * *","wakeAtCron":"1 * * * *"},{"isEnabled":true,"hibernateAtCron":"1 * * * *","wakeAtCron":"0 * * * *"}]}'
           dag_tarball_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_image_version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -814,7 +814,7 @@ jobs:
         with:
           is_wake_on_deploy: ${{ matrix.deployment_id == needs.create-test-deployments.outputs.HIBERNATE_DEPLOYMENT_ID }}
           dag_tarball_version_before: ""
-          image_version_before: "12.5.0"
+          image_version_before: "12.6.0"
           hibernation_spec_before: '{"schedules":[{"isEnabled":true,"hibernateAtCron":"0 * * * *","wakeAtCron":"1 * * * *"},{"isEnabled":true,"hibernateAtCron":"1 * * * *","wakeAtCron":"0 * * * *"}]}'
           dag_tarball_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_dag_tarball_version }}
           image_version_after: ${{ steps.get-deployment-after-create-preview.outputs.desired_image_version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/rebase-force-push
   workflow_dispatch:
     inputs:
       workspace_id:

--- a/action.yaml
+++ b/action.yaml
@@ -319,8 +319,8 @@ runs:
         GITHUB_EVENT_BEFORE=${{ github.event.before }}
         GITHUB_EVENT_AFTER=${{ github.event.after }}
         if [[ "$GITHUB_EVENT_BEFORE" == "0000000000000000000000000000000000000000" || -z $GITHUB_EVENT_BEFORE && -z $GITHUB_EVENT_AFTER ]]; then
-            DBT_DEPLOY=true
-            files=()
+          DBT_DEPLOY=true
+          files=()
         else
           files=$(git diff --name-only $GITHUB_EVENT_BEFORE $GITHUB_EVENT_AFTER)
           echo "files changed: $files"
@@ -367,18 +367,30 @@ runs:
         git fetch origin $branch
 
         DAGS_ONLY_DEPLOY=false
-        SKIP_IMAGE_OR_DAGS_DEPLOY=true
+        SKIP_IMAGE_OR_DAGS_DEPLOY=false
+        files=()
 
-        # case when the triggered event is a manual workflow dispatch or a new branch or tag creation, we would need to deploy the image because we cannot determine that it does not need to be deployed
         GITHUB_EVENT_BEFORE=${{ github.event.before }}
         GITHUB_EVENT_AFTER=${{ github.event.after }}
+        # case when the triggered event is a manual workflow dispatch or a new branch or tag creation, we would need to deploy the image because we cannot determine that it does not need to be deployed
         if [[ "$GITHUB_EVENT_BEFORE" == "0000000000000000000000000000000000000000" ||  -z $GITHUB_EVENT_BEFORE && -z $GITHUB_EVENT_AFTER ]]; then
-            DAGS_ONLY_DEPLOY=false
-            SKIP_IMAGE_OR_DAGS_DEPLOY=false
-            files=()
-        else
-          files=$(git diff --name-only $GITHUB_EVENT_BEFORE $GITHUB_EVENT_AFTER)
+          echo "Manual workflow dispatch or a new branch or tag creation, hence missing github event before and/or after commit hash"
+        elif [[ "$GITHUB_REF" == refs/pull/*/merge ]]; then
+          pr_number="${GITHUB_REF#refs/pull/}"
+          pr_number="${pr_number%%/*}"
+          echo "Pull request triggered the workflow: $pr_number"
+          DAGS_ONLY_DEPLOY=false
+          SKIP_IMAGE_OR_DAGS_DEPLOY=false
+          files=()
+        elif [[ "$GITHUB_REF" == refs/heads/* ]]; then
+          branch=$(echo "${GITHUB_REF#refs/heads/}")
+          echo "Branch push triggered the workflow: $branch"
+          git fetch origin $branch
+          SKIP_IMAGE_OR_DAGS_DEPLOY=true
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
           echo "files changed: $files"
+        else
+          echo "Unknown event type: $GITHUB_REF, using image deploy"
         fi
 
         for file in $files; do

--- a/action.yaml
+++ b/action.yaml
@@ -372,8 +372,8 @@ runs:
         if [[ "$GITHUB_EVENT_BEFORE" == "0000000000000000000000000000000000000000" ||  -z $GITHUB_EVENT_BEFORE && -z $GITHUB_EVENT_AFTER ]]; then
           echo "Manual workflow dispatch or a new branch or tag creation, hence missing github event before and/or after commit hash"
         else
+          echo "event that triggered the workflow: $GITHUB_REF"
           branch=$(echo "${GITHUB_REF#refs/heads/}")
-          echo "Branch push triggered the workflow: $branch"
           git fetch origin $branch
           if ! git cat-file -e "${{ github.event.before }}" 2>/dev/null; then
             echo "Commit ${{ github.event.before }} does not exist, falling back to image deploy."

--- a/action.yaml
+++ b/action.yaml
@@ -362,10 +362,6 @@ runs:
           cd ${{ inputs.root-folder }}
         fi
 
-        branch=$(echo "${GITHUB_REF#refs/heads/}")
-        echo "Branch pushed to: $branch"
-        git fetch origin $branch
-
         DAGS_ONLY_DEPLOY=false
         SKIP_IMAGE_OR_DAGS_DEPLOY=false
         files=()

--- a/action.yaml
+++ b/action.yaml
@@ -383,7 +383,12 @@ runs:
           echo "Branch push triggered the workflow: $branch"
           git fetch origin $branch
           SKIP_IMAGE_OR_DAGS_DEPLOY=true
-          files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          if ! git cat-file -e "${{ github.event.before }}" 2>/dev/null; then
+            echo "Commit ${{ github.event.before }} does not exist, falling back to HEAD."
+            files=$(git diff --name-only HEAD ${{ github.event.after }})
+          else
+            files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          fi
           echo "files changed: $files"
         else
           echo "Unknown event type: $GITHUB_REF, using image deploy"

--- a/action.yaml
+++ b/action.yaml
@@ -382,6 +382,7 @@ runs:
             files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
             echo "files changed: $files"
           fi
+        fi
 
         for file in $files; do
           if [[ $file =~ ^"${{ inputs.root-folder }}".* ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -382,11 +382,10 @@ runs:
           branch=$(echo "${GITHUB_REF#refs/heads/}")
           echo "Branch push triggered the workflow: $branch"
           git fetch origin $branch
-          SKIP_IMAGE_OR_DAGS_DEPLOY=true
           if ! git cat-file -e "${{ github.event.before }}" 2>/dev/null; then
-            echo "Commit ${{ github.event.before }} does not exist, falling back to HEAD."
-            files=$(git diff --name-only HEAD ${{ github.event.after }})
+            echo "Commit ${{ github.event.before }} does not exist, falling back to image deploy."
           else
+            SKIP_IMAGE_OR_DAGS_DEPLOY=true
             files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
           fi
           echo "files changed: $files"

--- a/action.yaml
+++ b/action.yaml
@@ -371,14 +371,7 @@ runs:
         # case when the triggered event is a manual workflow dispatch or a new branch or tag creation, we would need to deploy the image because we cannot determine that it does not need to be deployed
         if [[ "$GITHUB_EVENT_BEFORE" == "0000000000000000000000000000000000000000" ||  -z $GITHUB_EVENT_BEFORE && -z $GITHUB_EVENT_AFTER ]]; then
           echo "Manual workflow dispatch or a new branch or tag creation, hence missing github event before and/or after commit hash"
-        elif [[ "$GITHUB_REF" == refs/pull/*/merge ]]; then
-          pr_number="${GITHUB_REF#refs/pull/}"
-          pr_number="${pr_number%%/*}"
-          echo "Pull request triggered the workflow: $pr_number"
-          DAGS_ONLY_DEPLOY=false
-          SKIP_IMAGE_OR_DAGS_DEPLOY=false
-          files=()
-        elif [[ "$GITHUB_REF" == refs/heads/* ]]; then
+        else
           branch=$(echo "${GITHUB_REF#refs/heads/}")
           echo "Branch push triggered the workflow: $branch"
           git fetch origin $branch
@@ -387,11 +380,8 @@ runs:
           else
             SKIP_IMAGE_OR_DAGS_DEPLOY=true
             files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+            echo "files changed: $files"
           fi
-          echo "files changed: $files"
-        else
-          echo "Unknown event type: $GITHUB_REF, using image deploy"
-        fi
 
         for file in $files; do
           if [[ $file =~ ^"${{ inputs.root-folder }}".* ]]; then

--- a/e2e-setup/astro-project/Dockerfile
+++ b/e2e-setup/astro-project/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:12.6.0
+FROM quay.io/astronomer/astro-runtime:12.7.1

--- a/e2e-setup/astro-project/Dockerfile
+++ b/e2e-setup/astro-project/Dockerfile
@@ -1,1 +1,1 @@
-FROM quay.io/astronomer/astro-runtime:12.5.0
+FROM quay.io/astronomer/astro-runtime:12.6.0

--- a/e2e-setup/deployment-templates/deployment-hibernate.yaml
+++ b/e2e-setup/deployment-templates/deployment-hibernate.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-hibernate-e2e
     description: ""
-    runtime_version: 12.5.0
+    runtime_version: 12.6.0
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL

--- a/e2e-setup/deployment-templates/deployment-hibernate.yaml
+++ b/e2e-setup/deployment-templates/deployment-hibernate.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-hibernate-e2e
     description: ""
-    runtime_version: 12.6.0
+    runtime_version: 12.7.1
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL

--- a/e2e-setup/deployment-templates/deployment.yaml
+++ b/e2e-setup/deployment-templates/deployment.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-non-dev-e2e
     description: ""
-    runtime_version: 12.5.0
+    runtime_version: 12.6.0
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL

--- a/e2e-setup/deployment-templates/deployment.yaml
+++ b/e2e-setup/deployment-templates/deployment.yaml
@@ -2,7 +2,7 @@ deployment:
   configuration:
     name: deploy-action-non-dev-e2e
     description: ""
-    runtime_version: 12.6.0
+    runtime_version: 12.7.1
     dag_deploy_enabled: true
     ci_cd_enforcement: false
     scheduler_size: SMALL

--- a/e2e-setup/mocks/dag-deploy-git.sh
+++ b/e2e-setup/mocks/dag-deploy-git.sh
@@ -7,6 +7,8 @@ if [[ "$1" == "diff" ]]; then
   echo "e2e-setup/astro-project/dags/exampledag.py"
 elif [[ "$1" == "fetch" ]]; then
   echo "Handling git fetch, doing nothing"
+elif [[ "$1" == "cat-file" ]]; then
+  echo "Handling git cat-file, doing nothing"
 else
   echo "Error: git mock script isn't configured to handle $1" >&2
   exit 1

--- a/e2e-setup/mocks/image-deploy-git.sh
+++ b/e2e-setup/mocks/image-deploy-git.sh
@@ -7,6 +7,8 @@ if [[ "$1" == "diff" ]]; then
   echo "e2e-setup/astro-project/Dockerfile"
 elif [[ "$1" == "fetch" ]]; then
   echo "Handling git fetch, doing nothing"
+elif [[ "$1" == "cat-file" ]]; then
+  echo "Handling git cat-file, doing nothing"
 else
   echo "Error: git mock script isn't configured to handle $1" >&2
   exit 1

--- a/e2e-setup/mocks/no-deploy-git.sh
+++ b/e2e-setup/mocks/no-deploy-git.sh
@@ -7,6 +7,8 @@ if [[ "$1" == "diff" ]]; then
    echo "README.md"
 elif [[ "$1" == "fetch" ]]; then
   echo "Handling git fetch, doing nothing"
+elif [[ "$1" == "cat-file" ]]; then
+  echo "Handling git cat-file, doing nothing"
 else
   echo "Error: git mock script isn't configured to handle $1" >&2
   exit 1


### PR DESCRIPTION
## Changes:
- Fix the case when force push would fail the deploy action around file diff computation
- Upgrade runtime versions in our tests
- Fix failing yq installation in the e2e test suite
- Dropped the failing manual workflow trigger for the e2e test suite, rather now the suite gets triggered on each commit push on all branches, but we rather have an approval step to ensure that we don't end up creating too many resources on Astro.

## Testing:
- The e2e tests are happy
- Manually validated the force push and rebase scenario to ensure that they are not running into issues
<img width="774" alt="Screenshot 2025-02-05 at 2 58 52 PM" src="https://github.com/user-attachments/assets/e97427ce-4028-4c58-8898-df74a0e366ae" />
<img width="676" alt="Screenshot 2025-02-05 at 1 53 59 PM" src="https://github.com/user-attachments/assets/5601283a-5d43-4a6f-a527-633dca3eb618" />
<img width="596" alt="Screenshot 2025-02-05 at 1 57 07 PM" src="https://github.com/user-attachments/assets/f07e21cc-14c6-4223-84ca-ab8e2bf00d7e" />

Relates to #95 