### PR TITLE
Add `cli-version` to docs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |
 | `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
 | `wake-on-deploy` | `false` | If true, the deployment will be woken up from hibernation before deploying. NOTE: This option overrides the deployment's hibernation override spec. |
-| `cli-version` | `false` | The desired Astro CLI version to use. The latest version is used if left unset. |
+| `cli-version` | `` | The desired Astro CLI version to use. The latest version is used if left unset. |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |
 | `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
 | `wake-on-deploy` | `false` | If true, the deployment will be woken up from hibernation before deploying. NOTE: This option overrides the deployment's hibernation override spec. |
+| `cli-version` | `false` | The desired Astro CLI version to use. The latest version is used if left unset. |
 
 
 ## Outputs


### PR DESCRIPTION
Adds a missing parameter to the docs in the readme.