### PR TITLE
Fix DBT_OPTIONS not populating due to incorrect DBT_DEPLOY check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -337,7 +337,7 @@ runs:
         done
 
         options=""
-        if [[ $dbt_deploy == 1 ]]; then
+        if [[ $DBT_DEPLOY == true ]]; then
           # Add mount path option
           if [[ "${{ inputs.mount-path }}" != "" ]]; then
             options="$options --mount-path=${{ inputs.mount-path }}"


### PR DESCRIPTION
This PR addresses a logic error where the condition for setting DBT_OPTIONS was incorrectly handled

### 🐞 **Problem:**
The conditional check used the wrong variable and value:
`if [[ $dbt_deploy == 1 ]]; then
`

- **Incorrect variable**: Used `$dbt_deploy` instead of `$DBT_DEPLOY`.
- **Incorrect condition**: Checked for `1` instead of the expected boolean value `true`.

As a result, the DBT_OPTIONS variable was not populated, so critical options like the mount path were missing from the final dbt deploy command.

### 🔧 **Fix**
Updated the condition to correctly check the DBT_DEPLOY flag:
`if [[ $DBT_DEPLOY == true ]]; then
`

✅ **Outcome** :
With this fix, the `DBT_OPTIONS` variable is now correctly populated, ensuring the dbt project deploys with the proper mount path and other necessary options

Reference: [Zendesk - 72769](https://astronomer.zendesk.com/agent/tickets/72769)