### PR TITLE
Fix flaky create preview deployment

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -224,7 +224,8 @@ runs:
           astro deployment create --deployment-file deployment-preview-template.yaml
 
           # Get final Deployment ID
-          echo "FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)" >> $GITHUB_OUTPUT
+          FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)
+          echo "FINAL_DEPLOYMENT_ID=$FINAL_DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
           # Get original Deployment ID
           echo "ORIGINAL_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -253,6 +253,7 @@ runs:
               DELAY=$((DELAY * 2))
               if [[ "$DELAY" -gt "$MAX_DELAY" ]]; then
                 echo ERROR: cannot create a deployment preview sucessfully, deployment is not healthy.
+                exit 1 # terminate and indicate error
               fi
           done
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -220,14 +220,40 @@ runs:
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
 
-          # Create new deployment preview based on the deployment template file and wait for 7 minutes to get the webserver ready
-          astro deployment create --deployment-file deployment-preview-template.yaml --wait 7m
+          # Create new deployment preview based on the deployment template file
+          astro deployment create --deployment-file deployment-preview-template.yaml
 
           # Get final Deployment ID
           echo "FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)" >> $GITHUB_OUTPUT
 
           # Get original Deployment ID
           echo "ORIGINAL_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+
+          DELAY=15
+          # Maximum DELAY cap (6 minutes)
+          MAX_DELAY=241
+
+          # Command to check the deployment status
+          INSPECT_DEPLOYMENT="astro deployment inspect $FINAL_DEPLOYMENT_ID  --clean-output --key metadata.status"
+
+          echo "Starting deployment health check..."
+
+          while true; do
+              status=$(eval "$INSPECT_DEPLOYMENT")
+              echo "Current status: $status"
+              if [ "$status" == "HEALTHY" ]; then
+                  echo "Deployment is healthy!"
+                  break
+              fi
+              echo "Preview deplyment $FINAL_DEPLOYMENT_ID not healthy yet. Retrying in $DELAY seconds..."
+              sleep $DELAY
+
+              # Exponentially increase DELAY but cap it at MAX_DELAY
+              DELAY=$((DELAY * 2))
+              if [[ "$DELAY" -gt "$MAX_DELAY" ]]; then
+                echo ERROR: cannot create a deployment preview sucessfully, deployment is not healthy.
+              fi
+          done
         fi
 
         # delete deployment preview and skip deploy if action is delete-deployment-preview

--- a/action.yaml
+++ b/action.yaml
@@ -231,8 +231,8 @@ runs:
           echo "ORIGINAL_DEPLOYMENT_ID=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
           DELAY=15
-          # Maximum DELAY cap (6 minutes)
-          MAX_DELAY=241
+          # Maximum DELAY cap (~8 minutes)
+          MAX_DELAY=481
 
           # Command to check the deployment status
           INSPECT_DEPLOYMENT="astro deployment inspect $FINAL_DEPLOYMENT_ID  --clean-output --key metadata.status"

--- a/action.yaml
+++ b/action.yaml
@@ -220,10 +220,8 @@ runs:
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
 
-          # Create new deployment preview based on the deployment template file
-          astro deployment create --deployment-file deployment-preview-template.yaml
-
-          # TODO: we need to add wait for deployment to be created, otherwise operation to copy airflow resources like connection is flaky if webserver is not up by then
+          # Create new deployment preview based on the deployment template file and wait for 7 minutes to get the webserver ready
+          astro deployment create --deployment-file deployment-preview-template.yaml --wait 7m
 
           # Get final Deployment ID
           echo "FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
close #115 

Implemented custom wait for `create-deployment-preview` action to create preview deployment, as a workaround for [limitation](https://github.com/astronomer/astro-cli/issues/1328)

# Testing

Tested with following workflow:
```
name: Astronomer CI - Create deployment preview

on:
  pull_request:
    types:
    - opened
    - reopened

jobs:
  deploy:
    runs-on: ubuntu-latest
    env:
      ASTRO_API_TOKEN: ${{ secrets.ASTRO_API_TOKEN }}
      DEPLOYMENT_ID: cm8azqepo1f8s01ktivfghusc
      WORKSPACE_ID: clilt7vco00a601kk5fz65ob1
    steps:
    - name: Create Deployment Preview
      uses: astronomer/deploy-action@fix-flaky-create-preview-deployment
      with:
        action: create-deployment-preview
        deployment-id: ${{ env.DEPLOYMENT_ID }}
        workspace: ${{ env.WORKSPACE_ID }}
```
## Positive case
```
     metadata:
          deployment_id: cm8b3lgh91f3q01n6cj44ukjl
          workspace_id: clilt7vco00a601kk5fz65ob1
          cluster_id: cluhqac4x04um01lo0ny85fbo
          release_name: N/A
          airflow_version: 2.10.5
          current_tag: 12.7.1
          status: CREATING
          created_at: 2025-03-16T03:50:36.817Z
          updated_at: 2025-03-16T03:50:37.62Z
          deployment_url: cloud.astronomer.io/clilt7vco00a601kk5fz65ob1/deployments/cm8b3lgh91f3q01n6cj44ukjl/overview
          webserver_url: org-astronomer-cre.astronomer.run/dj44ukjl?orgId=org_oIfBdEu454JapvK1
          airflow_api_url: org-astronomer-cre.astronomer.run/dj44ukjl/api/v1
      alert_emails:
          - somarajunagasaidurga.saketh@astronomer.io
  
  Starting deployment health check...
  Current status: CREATING
  Preview deplyment cm8b3lgh91f3q01n6cj44ukjl not healthy yet. Retrying in 15 seconds...
  Current status: CREATING
  Preview deplyment cm8b3lgh91f3q01n6cj44ukjl not healthy yet. Retrying in 30 seconds...
  Current status: CREATING
  Preview deplyment cm8b3lgh91f3q01n6cj44ukjl not healthy yet. Retrying in 60 seconds...
  Current status: HEALTHY
  Deployment is healthy!
Run echo ::group::Determine if DAG Deploy is enabled
```
## Negative Case - with intentionally injected failure in base deployment

```
   metadata:
          deployment_id: cm8b3vk2c1g5501ktsm5rze0h
          workspace_id: clilt7vco00a601kk5fz65ob1
          cluster_id: cluhqac4x04um01lo0ny85fbo
          release_name: N/A
          airflow_version: 2.10.5
          current_tag: 12.7.1
          status: CREATING
          created_at: 2025-03-16T03:58:28.012Z
          updated_at: 2025-03-16T03:58:28.779Z
          deployment_url: cloud.astronomer.io/clilt7vco00a601kk5fz65ob1/deployments/cm8b3vk2c1g5501ktsm5rze0h/overview
          webserver_url: org-astronomer-cre.astronomer.run/dm5rze0h?orgId=org_oIfBdEu454JapvK1
          airflow_api_url: org-astronomer-cre.astronomer.run/dm5rze0h/api/v1
      alert_emails:
          - somarajunagasaidurga.saketh@astronomer.io
  
  Starting deployment health check...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 15 seconds...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 30 seconds...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 60 seconds...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 120 seconds...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 240 seconds...
  Current status: CREATING
  Preview deplyment cm8b3vk2c1g5501ktsm5rze0h not healthy yet. Retrying in 480 seconds...
  ERROR: cannot create a deployment preview sucessfully, deployment is not healthy.
  Error: Process completed with exit code 1.
```