### PR TITLE
Add configurable worker queue settings for preview deployments

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,6 +82,18 @@ inputs:
   build-secrets:
     required: false
     description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
+  worker-max-count:
+    required: false
+    default: "10"
+    description: "Maximum number of workers for the worker queue in preview deployments"
+  worker-concurrency:
+    required: false
+    default: "1"
+    description: "Worker concurrency for the worker queue in preview deployments"
+  worker-type:
+    required: false
+    default: "A5"
+    description: "Worker type for the worker queue in preview deployments"
 outputs:
   preview-id:
     description: "The ID of the created deployment preview. Only works when action=create-deployment-preview"
@@ -163,6 +175,19 @@ runs:
 
           # Set scheduler size to small
           sed -i "s|  scheduler_size:.*|  scheduler_size: small|g" deployment-preview-template.yaml
+          
+          # Configure worker queues
+          yq eval '
+            .deployment.worker_queues = [
+              {
+                "name": "default",
+                "max_worker_count": ${{ inputs.worker-max-count }},
+                "min_worker_count": 0,
+                "worker_concurrency": ${{ inputs.worker-concurrency }},
+                "worker_type": "${{ inputs.worker-type }}"
+              }
+            ]
+          ' -i deployment-preview-template.yaml
           
           # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: "Deploy Apache Airflow DAGs to Astro"
 description: "Test your DAGs and deploy your Astro project to a Deployment on Astro, Astronomer's managed Airflow service."
 author: "Astronomer"
 branding:
-  icon: 'upload-cloud'
-  color: 'purple'
+  icon: "upload-cloud"
+  color: "purple"
 inputs:
   root-folder:
     required: false
@@ -94,7 +94,7 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout == 'true'
       with:
-        fetch-depth: 0  # Fetch all history
+        fetch-depth: 0 # Fetch all history
         ref: ${{ github.event.after }}
         clean: false
     - name: Install Astro CLI
@@ -160,6 +160,9 @@ runs:
 
           # Enable development mode
           sed -i "s|  is_development_mode:.*|  is_development_mode: true|g" deployment-preview-template.yaml
+
+          # Set scheduler size to small
+          sed -i "s|  scheduler_size:.*|  scheduler_size: small|g" deployment-preview-template.yaml
           
           # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml
@@ -355,8 +358,10 @@ runs:
       run: |
         if [[ ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
           astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
-          # Give it some time to wake up
-          sleep 60
+          while [ "$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key metadata.status)" == "HIBERNATING" ]
+          do
+            sleep 5
+          done
         fi
       shell: bash
     - name: DAG Deploy to Astro

--- a/action.yaml
+++ b/action.yaml
@@ -339,15 +339,15 @@ runs:
       shell: bash
       id: deploy-options
     - name: Determine if Development Mode is enabled
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false ]]; then
-          echo "DEVELOPMENT_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)" >> $GITHUB_OUTPUT
-        fi
+        echo "DEVELOPMENT_MODE=$(astro deployment inspect ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --clean-output --key configuration.is_development_mode)" >> $GITHUB_OUTPUT
       shell: bash
       id: development-mode
     - name: Override to wake up the Deployment
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false && ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
+        if [[ ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
           astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --force
           # Give it some time to wake up
           sleep 60
@@ -382,8 +382,9 @@ runs:
         fi
       shell: bash
     - name: Remove override on Deployment to resume schedule
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == false && ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
+        if [[ ${{steps.development-mode.outputs.DEVELOPMENT_MODE}} == true ]]; then
           astro deployment wake-up ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --remove-override --force
         fi
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -269,12 +269,13 @@ runs:
       shell: bash
       id: dag-deploy-enabled
     - name: Get Deployment Type
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         cd ${{ inputs.root-folder }}
         branch=$(echo "${GITHUB_REF#refs/heads/}")
         echo "Branch pushed to: $branch"
         git fetch origin $branch
-        files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+        files=$(git diff --name-only $(git rev-parse HEAD^) ${{ github.event.after }})
         echo "files changed: $files"
         dags_only=1
 
@@ -290,11 +291,6 @@ runs:
           dags_only=0
         fi
 
-        if [[ ${{steps.deployment-preview.outputs.SKIP_DEPLOY}} == true ]]; then
-          # skip all deploy steps
-          dags_only=2
-        fi
-
         if [[ ${{ inputs.deploy-image }} == true ]]; then
           # make sure image and DAGs deploys because deploy-image is true
           dags_only=0
@@ -305,6 +301,7 @@ runs:
       id: deployment-type
     # If only DAGs changed and dag deploys is enabled, do a DAG-only deploy
     - name: setup deploy options
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         options=""
 
@@ -357,19 +354,20 @@ runs:
         fi
       shell: bash
     - name: DAG Deploy to Astro
-      if: steps.deployment-type.outputs.DAGS_ONLY == 1
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false' && steps.deployment-type.outputs.DAGS_ONLY == 1
       run: |
         cd ${{ inputs.root-folder }}
         astro deploy ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} --dags ${{steps.deploy-options.outputs.OPTIONS}}
       shell: bash
     # If any other files changed or dag deploys is disabled, deploy the entire Astro project
     - name: Image and DAG Deploy to Astro
-      if: steps.deployment-type.outputs.DAGS_ONLY == 0
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false' && steps.deployment-type.outputs.DAGS_ONLY == 0
       run: |
         cd ${{ inputs.root-folder }}
         astro deploy ${{steps.deployment-preview.outputs.FINAL_DEPLOYMENT_ID}} ${{steps.deploy-options.outputs.OPTIONS}}
       shell: bash
     - name: Copy Airflow Connections, Variables, and Pools
+      if: steps.deployment-preview.outputs.SKIP_DEPLOY == 'false'
       run: |
         if [[ ${{ inputs.action }} == create-deployment-preview ]]; then
           if [[ ${{ inputs.copy-connections }} == true ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -155,6 +155,12 @@ runs:
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
 
+          # Disable HA mode
+          sed -i "s|  is_high_availability:.*|  is_high_availability: false|g"  deployment-preview-template.yaml
+
+          # Enable development mode
+          sed -i "s|  is_development_mode:.*|  is_development_mode: true|g" deployment-preview-template.yaml
+          
           # Create new deployment preview based on the deployment template file
           astro deployment create --deployment-file deployment-preview-template.yaml
 


### PR DESCRIPTION
## Summary
- Add worker-max-count input (default: 10)
- Add worker-concurrency input (default: 1)  
- Add worker-type input (default: A5)
- Configure worker queues in deployment template during preview creation
