### PR TITLE
fix: added wait after deployment creation to prevent 404s

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -130,11 +130,13 @@ runs:
           CLI_VERSION=$(astro version | awk '{print $4}')
         fi
 
+        # Ensure semver CLI is available for version comparisons
+        if ! command -v semver &> /dev/null; then
+          npm install -g semver
+        fi
+
         # Check if the Astro CLI version is less than 1.28.1 for dbt-deploy
         if [[ "${{ inputs.deploy-type }}" == "dbt" && $CLI_VERSION != "" ]]; then
-          #install semver to compare versions
-          npm install -g semver
-
           REQUIRED_VERSION="1.28.1"
           CURRENT_VERSION=$(astro version | awk '{print $4}')
           if ! semver -r ">${REQUIRED_VERSION}" "${CURRENT_VERSION}"; then
@@ -220,8 +222,22 @@ runs:
           # Add name to deployment template file
           sed -i "s|  name:.*|  name: ${BRANCH_DEPLOYMENT_NAME}|g"  deployment-preview-template.yaml
 
-          # Create new deployment preview based on the deployment template file
-          astro deployment create --wait --deployment-file deployment-preview-template.yaml
+          # Decide whether deployment create can run with --wait based on CLI version
+          CLI_VERSION=$(astro version | awk '{print $4}')
+          REQUIRED_WAIT_VERSION="1.37.0"
+
+          if command -v semver >/dev/null 2>&1 && [[ -n "$CLI_VERSION" ]] && semver -r ">=${REQUIRED_WAIT_VERSION}" "$CLI_VERSION" >/dev/null 2>&1; then
+            astro deployment create --wait --deployment-file deployment-preview-template.yaml
+          else
+            if ! command -v semver >/dev/null 2>&1; then
+              echo "semver CLI not available; continuing without deployment create --wait"
+            elif [[ -z "$CLI_VERSION" ]]; then
+              echo "Unable to determine Astro CLI version; continuing without deployment create --wait"
+            else
+              echo "Astro CLI $CLI_VERSION does not support deployment create --wait; continuing without it"
+            fi
+            astro deployment create --deployment-file deployment-preview-template.yaml
+          fi
 
           # Get final Deployment ID
           echo "FINAL_DEPLOYMENT_ID=$(astro deployment inspect --clean-output -n $BRANCH_DEPLOYMENT_NAME --key metadata.deployment_id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description:

This PR updates the deploy-action to use the `--wait` flag with `astro deploy` and `astro deployment create` commands.

Previously, deploy-action could hit flaky 404s when copying Connections, Variables, and Pools because`astro deploy` and or `astro deployment create`would return before the webserver/API was ready. By adding `--wait`, the action now blocks until the deployment is healthy, ensuring resources are copied reliably.

The support for wait feature was introduced in https://github.com/astronomer/astro-cli/pull/1919 and has been validated as part of the same.

### Impact

- Prevents intermittent 404 errors after deploy.
- Removes the need for manual sleeps in workflows.
- This PR fixes: https://github.com/astronomer/deploy-action/issues/115, https://github.com/astronomer/deploy-action/pull/116

### Validation: 

1) Confirmed it successfully waits if `--wait` is passed: 
```
36f5f951f60a: Pushed 
deploy-2025-09-18T03-59-02: digest: sha256:16e2d60496216c725a62fd2147f77cea74a1de65010e6e195d33300bXbc7b572b size: 7400
Deployed DAG bundle:  2025-09-18T04:02:47.9408803Z
Deployed Image Tag:  deploy-2025-09-18T03-59-02

Waiting for the deployment to become healthy…

This may take a few minutes
Deployment mbhatt-destination-deployment is now healthy
Successfully pushed image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful. To deploy dags only run astro deploy --dags.

 Access your Deployment:

 Deployment View: https://cloud.astronomer.io/clilXXXX/deployments/cmeXXX
 Airflow UI: https://org-XXXX.astronomer.run/dXXX

```
2) Confirmed it doesn't wait if `--wait` is not passed:
```
36f5f951f60a: Mounted from clilt7rt8009l01i7wf7xnz94/ccmeXXX 
deploy-2025-09-18T04-05-03: digest: sha256:16e2d60496216c725a62fd2147f77cea74a1de65010e6e195d33X0bbc7b572b size: 7400
Deployed DAG bundle:  2025-09-18T04:07:31.5752282Z
Deployed Image Tag:  deploy-2025-09-18T04-05-03
Successfully pushed image to Astronomer registry. Navigate to the Astronomer UI for confirmation that your deploy was successful. To deploy dags only run astro deploy --dags.

 Access your Deployment:

 Deployment View: https://cloud.astronomer.io/cXXXXXX/deployments/cmXXXX
 Airflow UI:https://org-XXXX.astronomer.run/dXXX
```