### PR TITLE
Decouple Astro CLI installation from the deploy action

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To use this GitHub action, you need:
 - A Deployment on Astro. See [Create a Deployment](https://docs.astronomer.io/astro/create-deployment).
 - An Organization, Workspace, or Deployment API Token. See [API Tokens](https://docs.astronomer.io/astro/workspace-api-tokens)
 - Or (deprecated) a Deployment API key ID and secret. See [Deployment API keys](https://docs.astronomer.io/astro/api-keys).
+- The Astro CLI installed and available in `PATH` before this action runs. Use [`astronomer/setup-astro-cli`](https://github.com/astronomer/setup-astro-cli) to install it as a step in your workflow.
 
 > [!TIP]
 > Astronomer recommends using [GitHub Actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to store `ASTRO_API_TOKEN` or Deployment API Keys. See the example in [Workflow file examples](https://github.com/astronomer/deploy-action#workflow-file-examples).
@@ -67,7 +68,6 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |
 | `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
 | `wake-on-deploy` | `false` | If true, the deployment will be woken up from hibernation before deploying. NOTE: This option overrides the deployment's hibernation override spec. |
-| `cli-version` | `` | The desired Astro CLI version to use. The latest version is used if left unset. |
 | `wait-time` | `` | The max time to wait for the deployment or deploy operation to finish successfully. If not specified, the default value would be 10 minutes. Expected value format - 300s or 5m |
 
 
@@ -122,6 +122,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Deploy to Astro
       uses: astronomer/deploy-action@v0.11.1
       with:
@@ -192,6 +196,10 @@ jobs:
     steps:
     - name: Check out the repo
       uses: actions/checkout@v6
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Create image tag
       id: image_tag
       run: echo ::set-output name=image_tag::astro-$(date +%Y%m%d%H%M%S)
@@ -292,6 +300,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Create Deployment Preview
       uses: astronomer/deploy-action@v0.11.1
       with:
@@ -318,6 +330,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Deploy to Deployment Preview
       uses: astronomer/deploy-action@v0.11.1
       with:
@@ -343,6 +359,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Deploy to Deployment Preview
       uses: astronomer/deploy-action@v0.11.1
       with:
@@ -370,6 +390,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Delete Deployment Preview
       uses: astronomer/deploy-action@v0.11.1
       with:
@@ -395,6 +419,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+    - name: Install Astro CLI
+      uses: astronomer/setup-astro-cli@v0.1
+      with:
+        version: "1.40.1"
     - name: Deploy to Astro
       uses: astronomer/deploy-action@v0.11.1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -130,7 +130,7 @@ runs:
           echo "ERROR: Astro CLI is not installed or not in PATH."
           echo "Install it before calling this action:"
           echo ""
-          echo "  - uses: astronomer/setup-astro-cli@v1"
+          echo "  - uses: astronomer/setup-astro-cli"
           echo ""
           exit 1
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -57,10 +57,6 @@ inputs:
     required: false
     default: true
     description: "Copy pools from the original Deployment to the new deployment preview."
-  cli-version:
-    required: false
-    default: ""
-    description: "The desired Astro CLI version to use"
   checkout:
     required: false
     default: true
@@ -122,16 +118,25 @@ runs:
       shell: bash
       run: |
         echo "The 'deploy-image' option is deprecated and will be removed in 1.0 release. Use 'deploy-type: image-and-dags' instead."
-    - name: Install Astro CLI
+    - name: Verify Astro CLI
+      env:
+        INPUT_DEPLOY_TYPE: ${{ inputs.deploy-type }}
+        INPUT_WAIT_TIME: ${{ inputs.wait-time }}
       run: |
+        echo ::group::Verify Astro CLI
 
-        echo ::group::Install Astro CLI
-        CLI_VERSION=${{ inputs.cli-version }}
-        # if Astro CLI is pre-installed, fetch it's version
-        if command -v astro &> /dev/null; then
-          # "astro version" commands returns the CLI version, its output is of the form: "Astro CLI Version: 1.29.0"
-          CLI_VERSION=$(astro version | awk '{print $4}')
+        # Verify Astro CLI is available
+        if ! command -v astro &> /dev/null; then
+          echo "ERROR: Astro CLI is not installed or not in PATH."
+          echo "Install it before calling this action:"
+          echo ""
+          echo "  - uses: astronomer/setup-astro-cli@v1"
+          echo ""
+          exit 1
         fi
+
+        # "astro version" commands returns the CLI version, its output is of the form: "Astro CLI Version: 1.29.0"
+        CLI_VERSION=$(astro version | awk '{print $4}')
 
         # Ensure semver CLI is available for version comparisons
         if ! command -v semver &> /dev/null; then
@@ -139,17 +144,16 @@ runs:
         fi
 
         # Check if the Astro CLI version is less than 1.28.1 for dbt-deploy
-        if [[ "${{ inputs.deploy-type }}" == "dbt" && $CLI_VERSION != "" ]]; then
+        if [[ "${INPUT_DEPLOY_TYPE}" == "dbt" && $CLI_VERSION != "" ]]; then
           REQUIRED_VERSION="1.28.1"
-          CURRENT_VERSION=$(astro version | awk '{print $4}')
-          if ! semver -r ">${REQUIRED_VERSION}" "${CURRENT_VERSION}"; then
+          if ! semver -r ">${REQUIRED_VERSION}" "${CLI_VERSION}"; then
             echo "DBT Deploy requires Astro CLI version $REQUIRED_VERSION or higher"
             exit 1
           fi
         fi
 
         # Check if the Astro CLI version is less than 1.38.0 for wait-time option
-        if [[ "${{ inputs.wait-time }}" != "" && $CLI_VERSION != "" ]]; then
+        if [[ "${INPUT_WAIT_TIME}" != "" && $CLI_VERSION != "" ]]; then
           REQUIRED_VERSION="1.38.0"
           if ! semver -r ">=${REQUIRED_VERSION}" "${CLI_VERSION}"; then
             echo "Wait time option requires Astro CLI version $REQUIRED_VERSION or higher"
@@ -157,22 +161,6 @@ runs:
           fi
         fi
 
-        # skip Astro CLI installation if already installed
-        if command -v astro &> /dev/null; then
-          echo "Astro CLI is already installed"
-          exit 0
-        fi
-
-        # check if CLI_VERSION does not starts with "v", then add "v" to it
-        if [[ $CLI_VERSION != "" && $CLI_VERSION != v* ]]; then
-          CLI_VERSION=v$CLI_VERSION
-        fi
-
-        if [[ $CLI_VERSION == "" ]]; then
-          curl -sSL https://install.astronomer.io | sudo bash -s
-        else
-          curl -sSL https://install.astronomer.io | sudo bash -s -- $CLI_VERSION
-        fi
         echo ::endgroup::
       shell: bash
     - name: Determine Deploy Deployment


### PR DESCRIPTION
We will be introducing a new setup-astro-cli GitHub Action. This PR removes Astro CLI installation steps from the deploy action.
- The cli-version input and the "Install Astro CLI" step have been removed.
- The action now expects the CLI to already be available in PATH and will fail with a clear error pointing to astronomer/setup-astro-cli if it is not.
- All README workflow examples have been updated to include an explicit astronomer/setup-astro-cli step.
- Implement intermediate environment variables to handle untrusted inputs for `deploy-type` and `wait-time`. See https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable
