### PR TITLE
Pin the actions we depend on, and set `persist-credentials: false`

### DIFF
--- a/.github/workflows/lint_yaml.yaml
+++ b/.github/workflows/lint_yaml.yaml
@@ -6,8 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           file_or_dir: action.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,9 @@ jobs:
     environment: e2e-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Redact Inputs
         run: |
@@ -52,7 +54,9 @@ jobs:
       REMOTE_DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.REMOTE_DEPLOYMENT_ID }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -133,7 +137,9 @@ jobs:
         deploy_type: [dags, image-and-dags]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -232,7 +238,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -318,7 +326,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -409,7 +419,9 @@ jobs:
         deploy_type: [dags, image-and-dags]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -502,7 +514,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -591,7 +605,9 @@ jobs:
         deploy_type: [infer, dbt, dags, image-and-dags, image-only]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -707,7 +723,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -793,7 +811,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -1050,7 +1070,9 @@ jobs:
           ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch
@@ -1321,7 +1343,9 @@ jobs:
     if: always()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Patch deploy-action for manual dispatch
         uses: ./.github/workflows/e2e/patch_action_for_dispatch

--- a/action.yaml
+++ b/action.yaml
@@ -110,12 +110,13 @@ runs:
   using: "composite"
   steps:
     - name: checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: inputs.checkout == 'true'
       with:
         fetch-depth: 0  # Fetch all history
         ref: ${{ github.event.after }}
         clean: false
+        persist-credentials: false
         submodules: ${{ inputs.checkout-submodules }}
     - name: Warn about deprecated deploy-image option
       if: inputs.deploy-image == true


### PR DESCRIPTION
These are largely quite tame, with only one 3rd-party action. Regardless, it's good practice for us to pin these.

It's possible `persist-credentials: false` may break some of our workflows, but I couldn't see any obvious candidates, so let's just run them and see.