### PR TITLE
Add image-trigger-paths and skip-unchanged inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The following table lists the configuration options for the Deploy to Astro acti
 | ---|---|--- |
 | `action` | `deploy` | Specify what action you would like to take. Use this option to create or delete deployment previews. Specify either `deploy`, `create-deployment-preview`, `delete-deployment-preview` or `deploy-deployment-preview`. If using `deploy` or `deploy-deployment-preview` one should also specify `deploy-type`. |
 | `deploy-type` | `infer` | Specify the type of deploy you would like to do. Use this option to deploy images and/or DAGs or DBT project. Possible options are `infer`, `dags-only`, `image-and-dags`, `image-only` or `dbt`. `infer` option would infer between DAG only deploy and image and DAG deploy based on updated files. For description on each deploy type checkout [deploy type details](https://github.com/astronomer/deploy-action#deploy-type-details) |
+| `image-trigger-paths` | `` | Comma- or newline-separated list of paths outside `root-folder` that should also trigger a deploy when changed. Useful in monorepos where files built or copied into the image at deploy time (e.g. generated protos) live outside the Astro project. A change under any of these paths forces an image deploy instead of being skipped. Paths are matched as prefixes against repo-root-relative file paths, so include a trailing slash to scope to a directory (e.g. `proto/`). Only applies to the `infer`, `image-and-dags`, and `image-only` deploy types. |
+| `skip-unchanged` | `true` | When `true` (default), the action skips the deploy if no changed files fall under `root-folder` (or `image-trigger-paths`). Set to `false` to disable this diff-based skip and always run the deploy dictated by `deploy-type`. This is the closest replacement for the deprecated `deploy-image: true` behavior. Only applies to the `infer`, `dags-only`, `image-and-dags`, and `image-only` deploy types. |
 | `deployment-id` | `false` | Specifies the id of the deployment you to make a preview from or are deploying too. |
 | `deployment-name` | `false` | Specifies The name of the deployment you want to make preview from or are deploying too. Cannot be used with `deployment-id` |
 | `description` |  | Configure a description for a deploy to Astro. Description will be visible in the Deploy History tab. |
@@ -105,6 +107,34 @@ The following section describe each of the deploy type input value in detail to 
 5. `dbt`: In this mode, deploy-action would run through all the file changes:
   - if there are no file changes in the configured root-folder then it skips deploy
   - otherwise it would do a dbt deploy
+
+### Deploying on changes outside `root-folder`
+
+By default the deploy is skipped when no changed files fall under `root-folder`. In monorepos, some files that end up in the
+image are built or copied in at deploy time and live outside the Astro project (e.g. generated protos), so a change to them
+would otherwise be skipped. Two inputs cover this:
+
+- `image-trigger-paths`: list the extra paths that feed the image. A change under any of them forces an image deploy while
+  still skipping genuinely unrelated pushes. Applies to `infer`, `image-and-dags`, and `image-only`.
+
+  ```yaml
+  with:
+    root-folder: airflow
+    deploy-type: image-and-dags
+    image-trigger-paths: |
+      proto/
+      shared/schemas/
+  ```
+
+- `skip-unchanged: false`: disables the diff-based skip entirely, so the deploy dictated by `deploy-type` runs on every
+  invocation. This is the closest replacement for the deprecated `deploy-image: true`.
+
+  ```yaml
+  with:
+    root-folder: airflow
+    deploy-type: image-and-dags
+    skip-unchanged: false
+  ```
 
 
 ## Installing the Astro CLI

--- a/action.yaml
+++ b/action.yaml
@@ -83,6 +83,23 @@ inputs:
     required: false
     default: "infer"
     description: "Specify the type of deploy you would like to do. Use this option to deploy only DAGs or the image or DBT project. Specify either 'infer', 'dags-only', 'image-and-dags', 'image-only', or 'dbt'. 'infer' option would infer between DAG only deploy and image and DAG deploy based on updated files. 'image-only' deploys the image without updating DAGs."
+  image-trigger-paths:
+    required: false
+    default: ""
+    description: >
+      Comma- or newline-separated list of paths outside `root-folder` that should also trigger a deploy when changed.
+      Useful in monorepos where files built or copied into the image at deploy time (e.g. generated protos) live outside
+      the Astro project. A change under any of these paths forces an image deploy instead of being skipped. Paths are
+      matched as prefixes against repo-root-relative file paths, so include a trailing slash to scope to a directory
+      (e.g. `proto/`). Only applies to the `infer`, `image-and-dags`, and `image-only` deploy types.
+  skip-unchanged:
+    required: false
+    default: true
+    description: >
+      When true (default), the action skips the deploy if no changed files fall under `root-folder` (or `image-trigger-paths`).
+      Set to false to disable this diff-based skip and always run the deploy dictated by `deploy-type` on every run. This is
+      the closest replacement for the deprecated `deploy-image: true` behavior. Only applies to the `infer`, `dags-only`,
+      `image-and-dags`, and `image-only` deploy types.
   build-secrets:
     required: false
     description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
@@ -205,6 +222,18 @@ runs:
         # validate action input
         if [[ ${{ inputs.action }} != create-deployment-preview && ${{ inputs.action }} != delete-deployment-preview && ${{ inputs.action }} != deploy-deployment-preview && ${{ inputs.action }} != deploy ]]; then
           echo ERROR: you specified an improper action input. Action must be deploy, deploy-deployment-preview, create-deployment-preview, or delete-deployment-preview.
+          exit 1 # terminate and indicate error
+        fi
+
+        # validate deploy-type-specific inputs
+        # image-trigger-paths only affects image deploys, so it's a no-op for dags-only and dbt
+        if [[ -n "${{ inputs.image-trigger-paths }}" && ( "${{ inputs.deploy-type }}" == "dags-only" || "${{ inputs.deploy-type }}" == "dbt" ) ]]; then
+          echo "ERROR: image-trigger-paths is only supported with deploy-type infer, image-and-dags, or image-only"
+          exit 1 # terminate and indicate error
+        fi
+        # skip-unchanged gates the image/dags diff skip, which the dbt deploy path doesn't use
+        if [[ "${{ inputs.skip-unchanged }}" == "false" && "${{ inputs.deploy-type }}" == "dbt" ]]; then
+          echo "ERROR: skip-unchanged is only supported with deploy-type infer, dags-only, image-and-dags, or image-only"
           exit 1 # terminate and indicate error
         fi
 
@@ -420,7 +449,17 @@ runs:
 
         DAGS_ONLY_DEPLOY=false
         SKIP_IMAGE_OR_DAGS_DEPLOY=false
+        IMAGE_TRIGGER_MATCHED=false
         files=()
+
+        # collect image-trigger-paths (comma- or newline-separated), trimmed and non-empty
+        IMAGE_TRIGGER_PATHS="${{ inputs.image-trigger-paths }}"
+        IMAGE_TRIGGERS=()
+        while IFS= read -r trigger; do
+          trigger="${trigger#"${trigger%%[![:space:]]*}"}"
+          trigger="${trigger%"${trigger##*[![:space:]]}"}"
+          [[ -n "$trigger" ]] && IMAGE_TRIGGERS+=("$trigger")
+        done <<< "${IMAGE_TRIGGER_PATHS//,/$'\n'}"
 
         GITHUB_EVENT_BEFORE=${{ github.event.before }}
         GITHUB_EVENT_AFTER=${{ github.event.after }}
@@ -441,6 +480,15 @@ runs:
         fi
 
         for file in $files; do
+          # changes under any configured image-trigger-path force a full image deploy, even when
+          # the file lives outside root-folder (e.g. generated protos baked into the image at build time)
+          for trigger in "${IMAGE_TRIGGERS[@]}"; do
+            if [[ $file == "$trigger"* ]]; then
+              echo "$file matches image-trigger-path '$trigger', forcing an image deploy"
+              IMAGE_TRIGGER_MATCHED=true
+            fi
+          done
+
           if [[ $file =~ ^"${{ inputs.root-folder }}".* ]]; then
             echo $file is part of the input root folder
             SKIP_IMAGE_OR_DAGS_DEPLOY=false
@@ -480,6 +528,22 @@ runs:
         if [[ ${{ inputs.image-name }} != "no-custom-image" || "${{ steps.dag-deploy-enabled.outputs.DAG_DEPLOY_ENABLED }}" == "false" || ${{ inputs.action }} == create-deployment-preview ]]; then
           SKIP_IMAGE_OR_DAGS_DEPLOY=false
           DAGS_ONLY_DEPLOY=false
+        fi
+
+        # a change under image-trigger-paths forces a full image deploy, even if nothing under root-folder changed
+        if [[ $IMAGE_TRIGGER_MATCHED == true ]]; then
+          SKIP_IMAGE_OR_DAGS_DEPLOY=false
+          DAGS_ONLY_DEPLOY=false
+        fi
+
+        # skip-unchanged=false disables the diff-based skip entirely and always honors deploy-type
+        if [[ "${{ inputs.skip-unchanged }}" == "false" ]]; then
+          SKIP_IMAGE_OR_DAGS_DEPLOY=false
+          # for dags-only, ensure the dag deploy runs even when nothing under root-folder changed;
+          # other deploy types keep their already-inferred image/dags decision
+          if [[ ${{ inputs.deploy-type }} == 'dags-only' ]]; then
+            DAGS_ONLY_DEPLOY=true
+          fi
         fi
 
         if [[ ${{ inputs.action }} == delete-deployment-preview ]]; then


### PR DESCRIPTION
## what

adds two inputs to close the gap left by the deprecated `deploy-image` flag, reported in #155

- `image-trigger-paths`: comma/newline list of paths outside `root-folder` that should also trigger a deploy when changed. models the monorepo case where files baked into the image at build time (e.g. generated protos) live outside the Astro project. a change under any of them forces an image deploy while unrelated pushes still skip
- `skip-unchanged` (default `true`): set to `false` to disable the diff-based skip entirely and always honor `deploy-type`. this is the closest 1:1 replacement for `deploy-image: true`

## why

when `deploy-image` was deprecated in favor of `deploy-type`, the replacement lost the "deploy even when `root-folder` shows no diff" behavior the old flag had. `deploy-type: image-and-dags` still runs through the same skip check, so there was no non-deprecated way to force an image deploy off changes outside `root-folder`. these two inputs give that capability a real home so `deploy-image` can eventually go away

## testing

- ran a real end-to-end deploy on stage: a push touching only `proto/` (outside `root-folder`) built and deployed a real image, and a push touching only an unrelated top-level file correctly skipped
- unit-style harness that renders and runs the action's actual `Get Deploy Type` bash against mocked diffs covers image-trigger-paths (image vs dags-only vs skip), skip-unchanged, and regressions (defaults unchanged, delete-preview precedence)

closes #155

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJw7cWHVQdoccfmfrUn4B
