### PR TITLE
Remove redundant git fetch that breaks private-repo deploys

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -365,10 +365,8 @@ runs:
           cd ${{ inputs.root-folder }}
         fi
 
-        branch=$(echo "${GITHUB_REF#refs/heads/}")
-        echo "Branch pushed to: $branch"
-        git fetch origin $branch
-
+        # the diff below relies on history already present from the fetch-depth: 0 checkout;
+        # don't add a `git fetch` here, it fails on private repos due to persist-credentials: false
         DBT_DEPLOY=false
 
         # case when the triggered event is a manual workflow dispatch or a new branch or tag creation, we would need to deploy the dbt project because we cannot determine that it does not need to be deployed
@@ -429,8 +427,8 @@ runs:
           echo "Manual workflow dispatch or a new branch or tag creation, hence missing github event before and/or after commit hash"
         else
           echo "event that triggered the workflow: $GITHUB_REF"
-          branch=$(echo "${GITHUB_REF#refs/heads/}")
-          git fetch origin $branch
+          # history is already present from the fetch-depth: 0 checkout, so no fetch is needed;
+          # a `git fetch` here would also fail on private repos due to persist-credentials: false
           if ! git cat-file -e "${{ github.event.before }}" 2>/dev/null; then
             echo "Commit ${{ github.event.before }} does not exist, falling back to image deploy."
           else


### PR DESCRIPTION
## what

removes the two bare `git fetch origin $branch` calls in the "Get DBT Deploy Options" and "Get Deploy Type" steps

## why

the checkout step sets `persist-credentials: false` (#146), so no auth token is left in the git config after checkout. on a private repo the action's own `git fetch origin $branch` then fails with `fatal: could not read Username for 'https://github.com'` and aborts the deploy. public repos never hit it because they fetch anonymously

the fetch is redundant anyway: checkout already runs with `fetch-depth: 0`, so the full history (including `github.event.before`) is present locally, and the `git diff` / `git cat-file` that follow are local operations. the branch tip the fetch would pull is `github.event.after`, which is already checked out

## testing

reproduced the failure on a private repo (deploy died at `git fetch origin` with `could not read Username`), then confirmed this branch runs clean on the same private repo: `git diff before after` resolves against the local history and a full image + dags deploy completes on stage, no fetch error

## note

this is a latent regression - the `persist-credentials: false` change is on `main` but not in any release yet (latest is v0.13.0, which predates it), so no released user is affected. worth landing before the next release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeJw7cWHVQdoccfmfrUn4B
