### PR TITLE
Support multiple Docker build secrets via newline-delimited input

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following table lists the configuration options for the Deploy to Astro acti
 | `preview-name` | `false` | Specifies custom preview name. By default this is branch name “_” deployment name. |
 | `checkout` | `true` | Whether to checkout the repo as the first step. Set this to false if you want to modify repo contents before invoking the action. Your custom checkout step needs to have `fetch-depth` of `0` and `ref` equal to `${{ github.event.after }}` so all the commits in the PR are checked out. Look at the checkout step that runs within this action for reference. |
 | `deploy-image` | `false` | If true image and DAGs will deploy for any action that deploys code. NOTE: This option is deprecated and will be removed in a future release. Use `deploy-type: image-and-dags` instead. |
-| `build-secrets` | `` | Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'. |
+| `build-secrets` | `` | Newline-delimited list of Docker build secrets, one `docker build --secret` specification per line (e.g. `id=mysecret,src=secrets.txt`). Each line is passed to `astro deploy` as its own `--build-secret` flag. See https://docs.docker.com/build/building/secrets/ for more information. |
 | `mount-path` | `` | Path to mount dbt project in Airflow, for reference by DAGs. Default /usr/local/airflow/dbt/{dbt project name} |
 | `checkout-submodules` | `false` | Whether to checkout submodules when cloning the repository: `false` to disable (default), `true` to checkout submodules or `recursive` to recursively checkout submodules. Works only when `checkout` is set to `true`. Works only when `checkout` is set to `true`. |
 | `sparse-checkout` | `` | Comma- or newline-separated list of cone-mode sparse-checkout patterns passed to `actions/checkout`. When set, only the listed paths (plus repo-root files) are checked out, which can dramatically reduce checkout size for large monorepos. Typically set to the same value as `root-folder`. Works only when `checkout` is set to `true`. Leave empty for a full checkout (default). |
@@ -280,6 +280,32 @@ steps:
   with:
     deployment-id: <deployment id>
     force: true
+```
+
+### Use Docker build secrets
+
+In the following example, two [Docker build secrets](https://docs.docker.com/build/building/secrets/) are exposed to the image build: one sourced from a file on the runner and one from an environment variable. The `build-secrets` input takes one secret specification per line.
+
+```yaml
+steps:
+- name: Deploy to Astro
+  uses: astronomer/deploy-action@v0.15.0
+  env:
+    PLATFORM_PASSWORD: ${{ secrets.PLATFORM_PASSWORD }}
+  with:
+    deployment-id: <deployment id>
+    build-secrets: |
+      id=aws,src=/home/runner/.aws/credentials
+      id=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD
+```
+
+Your Astro project's Dockerfile can then mount the secrets during the build without baking them into the image:
+
+```dockerfile
+RUN --mount=type=secret,id=aws \
+    --mount=type=secret,id=PLATFORM_PASSWORD,env=PLATFORM_PASSWORD \
+    AWS_SHARED_CREDENTIALS_FILE=/run/secrets/aws \
+    ./install-private-dependencies.sh
 ```
 
 ### Deploy a custom Docker image

--- a/action.yaml
+++ b/action.yaml
@@ -102,7 +102,10 @@ inputs:
       `image-and-dags`, and `image-only` deploy types.
   build-secrets:
     required: false
-    description: "Mimics docker build --secret flag. See https://docs.docker.com/build/building/secrets/ for more information. Example input 'id=mysecret,src=secrets.txt'"
+    description: >
+      Newline-delimited list of Docker build secrets, one `docker build --secret` specification per line, e.g.
+      'id=mysecret,src=secrets.txt'. Each line is passed to `astro deploy` as its own `--build-secret` flag.
+      See https://docs.docker.com/build/building/secrets/ for more information.
   mount-path:
     required: false
     default: ""
@@ -601,14 +604,46 @@ runs:
           options="$options --description '${{ inputs.description }}'"
         fi
 
-        # Add build-secrets option
-        if [[ "${{ inputs.build-secrets }}" != '' ]]; then
-          options="$options --build-secrets '${{ inputs.build-secrets }}'"
+        # add build secret option(s)
+        if [[ -n "$BUILD_SECRETS" ]]; then
+          secrets=()
+          while IFS= read -r secret; do
+            if [[ -n "$secret" ]]; then
+              secrets+=("$secret")
+            fi
+          done <<< "$BUILD_SECRETS"
+
+          CLI_VERSION=""
+          if command -v astro &> /dev/null; then
+            CLI_VERSION=$(astro version | awk '{print $4}')
+          fi
+
+          # `--build-secrets` was added in v1.44.0.
+          #
+          # If we're running a version earlier than that, use `--build-secrets`,
+          # and only support a single entry.
+          BUILD_SECRET_MULTI=true
+          if [[ -n "$CLI_VERSION" ]] && command -v semver >/dev/null 2>&1 && ! semver -r ">=1.44.0" "$CLI_VERSION" >/dev/null 2>&1; then
+            BUILD_SECRET_MULTI=false
+          fi
+
+          if [[ ${#secrets[@]} -gt 0 && $BUILD_SECRET_MULTI == false ]]; then
+            if [[ ${#secrets[@]} -gt 1 ]]; then
+              echo "::warning::This version of the Astro CLI accepts only a single build secret: only the first line in 'build-secrets' will be used. Set cli-version to 1.44.0 or later to use multiple build secrets."
+            fi
+            options="$options --build-secrets '${secrets[0]}'"
+          else
+            for secret in "${secrets[@]}"; do
+              options="$options --build-secret '$secret'"
+            done
+          fi
         fi
 
         echo "OPTIONS=$options" >> $GITHUB_OUTPUT
         echo ::endgroup::
       shell: bash
+      env:
+        BUILD_SECRETS: ${{ inputs.build-secrets }}
       id: deploy-options
     - name: Determine if Development Mode is enabled
       if: ${{ inputs.wake-on-deploy == 'true' && inputs.action != 'delete-deployment-preview' }}


### PR DESCRIPTION
The build-secrets input was passed to `astro deploy --build-secrets` as a single argument, and the CLI in turn passed it to `docker build` as a single --secret flag, so there was no way to expose more than one secret to the image build: Docker parses the whole value as one secret spec in which later fields override earlier ones.

Change the input to accept a newline-delimited list. Each line is passed to the CLI as its own `--build-secret` flag.

As a side benefit, this input value is now threaded through the environment rather than interpolated into the script, so values containing shell metacharacters can no longer break (or inject into) the options-building step.

Fixes #72.

~_**Note:** this cannot be merged until https://github.com/astronomer/astro-cli/pull/2212 is merged and released._~